### PR TITLE
Manage hegel binary via pinned .hegel/venv

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -3,7 +3,7 @@
 ## Build Commands
 
 ```bash
-just setup   # Install dependencies and hegel binary
+just setup   # Install npm dependencies
 just test    # Run tests with coverage (fails if coverage < 100%)
 just format  # Auto-format code
 just lint    # Check formatting + linting
@@ -11,7 +11,7 @@ just docs    # Build API documentation
 just check   # Run lint + docs + test (full CI check)
 ```
 
-Tests must use `PATH=".venv/bin:$PATH"` so the `hegel` binary is found.
+The SDK automatically manages the hegel binary in `.hegel/venv`. Set `HEGEL_CMD` to override.
 
 ## What This Is
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -11,7 +11,7 @@ just docs    # Build API documentation
 just check   # Run lint + docs + test (full CI check)
 ```
 
-The SDK automatically manages the hegel binary in `.hegel/venv`. Set `HEGEL_CMD` to override.
+The SDK automatically manages the hegel binary in `.hegel/venv`. Set `HEGEL_SERVER_COMMAND` to override.
 
 ## What This Is
 

--- a/.github/scripts/release.py
+++ b/.github/scripts/release.py
@@ -64,24 +64,6 @@ def add_changelog(path: Path, *, version: str, content: str) -> None:
     path.write_text(f"# Changelog\n\n{entry}{rest}")
 
 
-def pin_hegel_version(session_ts: Path) -> None:
-    """Pin HEGEL_VERSION to the latest hegel-core release tag."""
-    tag = subprocess.check_output(
-        ["gh", "api", "repos/antithesishq/hegel-core/releases/latest", "--jq", ".tag_name"],
-        text=True,
-    ).strip()
-
-    text = session_ts.read_text()
-    new_text = re.sub(
-        r'^const HEGEL_VERSION = ".*"',
-        f'const HEGEL_VERSION = "{tag}"',
-        text,
-        count=1,
-        flags=re.MULTILINE,
-    )
-    session_ts.write_text(new_text)
-
-
 def check(base_ref: str) -> None:
     output = subprocess.check_output(
         ["git", "diff", "--name-only", f"origin/{base_ref}...HEAD"],
@@ -137,14 +119,11 @@ def release() -> None:
 
     set_version(package_json, new_version)
 
-    session_ts = ROOT / "src" / "session.ts"
-    pin_hegel_version(session_ts)
-
     add_changelog(ROOT / "CHANGELOG.md", version=new_version, content=content)
 
     git("config", "user.name", "hegel-release[bot]", cwd=ROOT)
     git("config", "user.email", "noreply@github.com", cwd=ROOT)
-    git("add", "package.json", "src/session.ts", "CHANGELOG.md", cwd=ROOT)
+    git("add", "package.json", "CHANGELOG.md", cwd=ROOT)
     git("rm", "RELEASE.md", cwd=ROOT)
     git(
         "commit",

--- a/.github/scripts/release.py
+++ b/.github/scripts/release.py
@@ -64,6 +64,24 @@ def add_changelog(path: Path, *, version: str, content: str) -> None:
     path.write_text(f"# Changelog\n\n{entry}{rest}")
 
 
+def pin_hegel_version(session_ts: Path) -> None:
+    """Pin HEGEL_VERSION to the current HEAD of hegel-core main."""
+    sha = subprocess.check_output(
+        ["gh", "api", "repos/antithesishq/hegel-core/commits/main", "--jq", ".sha"],
+        text=True,
+    ).strip()
+
+    text = session_ts.read_text()
+    new_text = re.sub(
+        r'^const HEGEL_VERSION = ".*"',
+        f'const HEGEL_VERSION = "{sha}"',
+        text,
+        count=1,
+        flags=re.MULTILINE,
+    )
+    session_ts.write_text(new_text)
+
+
 def check(base_ref: str) -> None:
     output = subprocess.check_output(
         ["git", "diff", "--name-only", f"origin/{base_ref}...HEAD"],
@@ -119,11 +137,14 @@ def release() -> None:
 
     set_version(package_json, new_version)
 
+    session_ts = ROOT / "src" / "session.ts"
+    pin_hegel_version(session_ts)
+
     add_changelog(ROOT / "CHANGELOG.md", version=new_version, content=content)
 
     git("config", "user.name", "hegel-release[bot]", cwd=ROOT)
     git("config", "user.email", "noreply@github.com", cwd=ROOT)
-    git("add", "package.json", "CHANGELOG.md", cwd=ROOT)
+    git("add", "package.json", "src/session.ts", "CHANGELOG.md", cwd=ROOT)
     git("rm", "RELEASE.md", cwd=ROOT)
     git(
         "commit",

--- a/.github/scripts/release.py
+++ b/.github/scripts/release.py
@@ -65,16 +65,16 @@ def add_changelog(path: Path, *, version: str, content: str) -> None:
 
 
 def pin_hegel_version(session_ts: Path) -> None:
-    """Pin HEGEL_VERSION to the current HEAD of hegel-core main."""
-    sha = subprocess.check_output(
-        ["gh", "api", "repos/antithesishq/hegel-core/commits/main", "--jq", ".sha"],
+    """Pin HEGEL_VERSION to the latest hegel-core release tag."""
+    tag = subprocess.check_output(
+        ["gh", "api", "repos/antithesishq/hegel-core/releases/latest", "--jq", ".tag_name"],
         text=True,
     ).strip()
 
     text = session_ts.read_text()
     new_text = re.sub(
         r'^const HEGEL_VERSION = ".*"',
-        f'const HEGEL_VERSION = "{sha}"',
+        f'const HEGEL_VERSION = "{tag}"',
         text,
         count=1,
         flags=re.MULTILINE,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,9 +65,9 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: ./.github/actions/base  # zizmor: ignore[secrets-outside-env]
+      - uses: ./.github/actions/base
         with:
-          ssh-key: ${{ secrets.HEGEL_DEPLOY_KEY }}
+          ssh-key: ${{ secrets.HEGEL_DEPLOY_KEY }} # zizmor: ignore[secrets-outside-env]
 
       - uses: astral-sh/setup-uv@d0d8abe699bfb85fec6de9f7adb5ae17292296ff # v6
 
@@ -107,9 +107,9 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: ./.github/actions/base  # zizmor: ignore[secrets-outside-env]
+      - uses: ./.github/actions/base
         with:
-          ssh-key: ${{ secrets.HEGEL_DEPLOY_KEY }}
+          ssh-key: ${{ secrets.HEGEL_DEPLOY_KEY }} # zizmor: ignore[secrets-outside-env]
 
       - uses: astral-sh/setup-uv@d0d8abe699bfb85fec6de9f7adb5ae17292296ff # v6
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,7 @@ jobs:
   test:
     name: test
     runs-on: ubuntu-latest
+    environment: ci
     permissions:
       contents: read
     steps:
@@ -69,8 +70,6 @@ jobs:
         with:
           ssh-key: ${{ secrets.HEGEL_DEPLOY_KEY }}
 
-      - name: Install just
-        run: sudo apt-get update && sudo apt-get install -y just
       - uses: astral-sh/setup-uv@d0d8abe699bfb85fec6de9f7adb5ae17292296ff # v6
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
@@ -78,7 +77,6 @@ jobs:
           node-version: "22"
 
       - run: npm ci
-      - run: just setup
       - name: Run tests
         run: npm run test
 
@@ -103,6 +101,7 @@ jobs:
   conformance:
     name: conformance
     runs-on: ubuntu-latest
+    environment: ci
     permissions:
       contents: read
     steps:
@@ -114,8 +113,6 @@ jobs:
         with:
           ssh-key: ${{ secrets.HEGEL_DEPLOY_KEY }}
 
-      - name: Install just
-        run: sudo apt-get update && sudo apt-get install -y just
       - uses: astral-sh/setup-uv@d0d8abe699bfb85fec6de9f7adb5ae17292296ff # v6
 
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
@@ -126,15 +123,20 @@ jobs:
         with:
           node-version: "22"
 
-      - run: just setup
+      - name: Install just
+        run: sudo apt-get update && sudo apt-get install -y just
+
+      - run: npm ci
       - run: pip install pytest
-      - run: just conformance
+      - name: Run conformance tests
+        run: just conformance
 
   release:
     name: release
     if: github.event_name == 'push' && github.repository == 'antithesishq/hegel-typescript'
     needs: [lint, test, docs, conformance]
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: write
       checks: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,6 +156,7 @@ jobs:
         with:
           app-id: ${{ vars.HEGEL_RELEASE_APP_ID }}
           private-key: ${{ secrets.HEGEL_RELEASE_APP_PRIVATE_KEY }}
+          repositories: hegel-typescript,hegel-core
 
       - name: Re-checkout with app token # zizmor: ignore[artipacked]
         if: steps.check.outputs.skip != 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
 
       - uses: ./.github/actions/base
         with:
-          ssh-key: ${{ secrets.HEGEL_DEPLOY_KEY }} # zizmor: ignore[secrets-outside-env]
+          ssh-key: ${{ secrets.HEGEL_DEPLOY_KEY }}
 
       - uses: astral-sh/setup-uv@d0d8abe699bfb85fec6de9f7adb5ae17292296ff # v6
 
@@ -109,7 +109,7 @@ jobs:
 
       - uses: ./.github/actions/base
         with:
-          ssh-key: ${{ secrets.HEGEL_DEPLOY_KEY }} # zizmor: ignore[secrets-outside-env]
+          ssh-key: ${{ secrets.HEGEL_DEPLOY_KEY }}
 
       - uses: astral-sh/setup-uv@d0d8abe699bfb85fec6de9f7adb5ae17292296ff # v6
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,6 @@ jobs:
     if: github.event_name == 'push' && github.repository == 'antithesishq/hegel-typescript'
     needs: [lint, test, docs, conformance]
     runs-on: ubuntu-latest
-    environment: release
     permissions:
       contents: write
       checks: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,6 @@ jobs:
   test:
     name: test
     runs-on: ubuntu-latest
-    environment: ci
     permissions:
       contents: read
     steps:
@@ -66,7 +65,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: ./.github/actions/base
+      - uses: ./.github/actions/base  # zizmor: ignore[secrets-outside-env]
         with:
           ssh-key: ${{ secrets.HEGEL_DEPLOY_KEY }}
 
@@ -101,7 +100,6 @@ jobs:
   conformance:
     name: conformance
     runs-on: ubuntu-latest
-    environment: ci
     permissions:
       contents: read
     steps:
@@ -109,7 +107,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: ./.github/actions/base
+      - uses: ./.github/actions/base  # zizmor: ignore[secrets-outside-env]
         with:
           ssh-key: ${{ secrets.HEGEL_DEPLOY_KEY }}
 

--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ version of [hegel-core](https://github.com/antithesishq/hegel-core) into it.
 Subsequent runs reuse the cached binary unless the pinned version changes.
 
 To use your own `hegel` binary instead (e.g. a local development build), set
-the `HEGEL_CMD` environment variable:
+the `HEGEL_SERVER_COMMAND` environment variable:
 
 ```bash
-export HEGEL_CMD=/path/to/hegel
+export HEGEL_SERVER_COMMAND=/path/to/hegel
 ```
 
 The SDK requires [`uv`](https://docs.astral.sh/uv/) to be installed for

--- a/README.md
+++ b/README.md
@@ -13,11 +13,22 @@ shrinks them to minimal counterexamples.
 npm install "git+ssh://git@github.com/antithesishq/hegel-typescript.git"
 ```
 
-The SDK requires the `hegel` CLI on your PATH:
+### Hegel server
+
+The SDK automatically manages the `hegel` server binary. On first use it
+creates a project-local `.hegel/venv` virtualenv and installs the pinned
+version of [hegel-core](https://github.com/antithesishq/hegel-core) into it.
+Subsequent runs reuse the cached binary unless the pinned version changes.
+
+To use your own `hegel` binary instead (e.g. a local development build), set
+the `HEGEL_CMD` environment variable:
 
 ```bash
-pip install "hegel @ git+ssh://git@github.com/antithesishq/hegel-core.git"
+export HEGEL_CMD=/path/to/hegel
 ```
+
+The SDK requires [`uv`](https://docs.astral.sh/uv/) to be installed for
+automatic server management.
 
 ## Quick Start
 
@@ -41,8 +52,8 @@ For a full walkthrough, see [guide/getting-started.md](guide/getting-started.md)
 ## Development
 
 ```bash
-just setup   # Install dependencies + hegel binary
+just setup   # Install npm dependencies
 just check   # Full CI: lint + docs + tests with 100% coverage
-just test    # Run tests only
+just test    # Run tests only (auto-installs hegel on first run)
 just format  # Auto-format code
 ```

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,3 @@
 RELEASE_TYPE: minor
 
-Manage hegel binary via pinned .hegel/venv instead of relying on system installation.
+Automatically manage hegel server installation. Adds a runtime requirement on `uv`.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: minor
+
+Manage hegel binary via pinned .hegel/venv instead of relying on system installation.

--- a/guide/getting-started.md
+++ b/guide/getting-started.md
@@ -6,13 +6,16 @@
 npm install "git+ssh://git@github.com/antithesishq/hegel-typescript.git"
 ```
 
-The SDK requires the `hegel` CLI on your PATH:
+The SDK automatically manages the `hegel` server binary. On first use it
+creates a project-local `.hegel/venv` virtualenv and installs the pinned
+version of [hegel-core](https://github.com/antithesishq/hegel-core) into it.
+You need [`uv`](https://docs.astral.sh/uv/) on your PATH for this to work.
+
+To use your own `hegel` binary instead, set `HEGEL_CMD`:
 
 ```bash
-pip install "git+ssh://git@github.com/antithesishq/hegel-core.git"
+export HEGEL_CMD=/path/to/hegel
 ```
-
-If you are working inside this repository, `just setup` handles both steps.
 
 ## Write your first test
 

--- a/guide/getting-started.md
+++ b/guide/getting-started.md
@@ -11,10 +11,10 @@ creates a project-local `.hegel/venv` virtualenv and installs the pinned
 version of [hegel-core](https://github.com/antithesishq/hegel-core) into it.
 You need [`uv`](https://docs.astral.sh/uv/) on your PATH for this to work.
 
-To use your own `hegel` binary instead, set `HEGEL_CMD`:
+To use your own `hegel` binary instead, set `HEGEL_SERVER_COMMAND`:
 
 ```bash
-export HEGEL_CMD=/path/to/hegel
+export HEGEL_SERVER_COMMAND=/path/to/hegel
 ```
 
 ## Write your first test

--- a/justfile
+++ b/justfile
@@ -1,25 +1,20 @@
 # Hegel SDK for typescript
 # This justfile provides the standard build recipes.
 
-# Install dependencies and the hegel binary.
-# If HEGEL_BINARY is set, symlinks it into .venv/bin instead of installing from git.
+# Install dependencies.
+# If HEGEL_BINARY is set, uses it as the hegel binary via HEGEL_CMD.
 setup:
     #!/usr/bin/env bash
     set -euo pipefail
-    uv venv .venv
-    if [ -n "${HEGEL_BINARY:-}" ]; then
-        mkdir -p .venv/bin
-        ln -sf "$HEGEL_BINARY" .venv/bin/hegel
-    else
-        uv pip install --python .venv/bin/python hegel@git+ssh://git@github.com/antithesishq/hegel-core.git
-    fi
     npm install
+    if [ -n "${HEGEL_BINARY:-}" ]; then
+        export HEGEL_CMD="$HEGEL_BINARY"
+    fi
 
 # Run tests with coverage enforcement (100% required).
 test:
     #!/usr/bin/env bash
     set -euo pipefail
-    export PATH=".venv/bin:$PATH"
     npx vitest run --coverage
     python3 scripts/check-coverage.py
 

--- a/justfile
+++ b/justfile
@@ -56,5 +56,15 @@ conformance: build-conformance
     uv pip install --python .venv/bin/python pytest hypothesis > /dev/null 2>&1 || true
     .venv/bin/python -m pytest tests/conformance/ -v
 
+# Update the pinned hegel-core version to the latest release.
+update-hegel-core-version:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    tag=$(gh api repos/antithesishq/hegel-core/releases/latest --jq '.tag_name')
+    sed -i '' "s/^const HEGEL_VERSION = \".*\"/const HEGEL_VERSION = \"${tag}\"/" src/session.ts
+    echo "Updated HEGEL_VERSION to ${tag}"
+    # Clear cached install so the next test run picks up the new version
+    rm -rf .hegel/venv
+
 # Run lint + docs + test (the full CI check).
 check: lint docs test

--- a/justfile
+++ b/justfile
@@ -2,13 +2,13 @@
 # This justfile provides the standard build recipes.
 
 # Install dependencies.
-# If HEGEL_BINARY is set, uses it as the hegel binary via HEGEL_CMD.
+# If HEGEL_BINARY is set, uses it as the hegel binary via HEGEL_SERVER_COMMAND.
 setup:
     #!/usr/bin/env bash
     set -euo pipefail
     npm install
     if [ -n "${HEGEL_BINARY:-}" ]; then
-        export HEGEL_CMD="$HEGEL_BINARY"
+        export HEGEL_SERVER_COMMAND="$HEGEL_BINARY"
     fi
 
 # Run tests with coverage enforcement (100% required).

--- a/src/session.ts
+++ b/src/session.ts
@@ -22,7 +22,7 @@ import { Client } from "./runner.js";
 /** The hegel-core commit this SDK is designed to work with. */
 const HEGEL_VERSION = "v0.3.3";
 
-const HEGEL_CMD_ENV = "HEGEL_CMD";
+const HEGEL_SERVER_COMMAND_ENV = "HEGEL_SERVER_COMMAND";
 
 const HEGEL_DIR = ".hegel";
 const VENV_DIR = path.join(HEGEL_DIR, "venv");
@@ -66,7 +66,7 @@ function ensureHegelInstalled(): string {
   } catch {
     throw new Error(
       `Failed to install hegel (version: ${HEGEL_VERSION}). ` +
-        `Set ${HEGEL_CMD_ENV} to a hegel binary path to skip installation.`,
+        `Set ${HEGEL_SERVER_COMMAND_ENV} to a hegel binary path to skip installation.`,
     );
   }
 
@@ -86,15 +86,15 @@ function ensureHegelInstalled(): string {
 /**
  * Locate the hegel binary.
  *
- * If `HEGEL_CMD` is set, uses that path directly (the user is responsible
+ * If `HEGEL_SERVER_COMMAND` is set, uses that path directly (the user is responsible
  * for providing the right binary).
  *
  * Otherwise, ensures hegel is installed in `.hegel/venv` at the version
  * specified by `HEGEL_VERSION` and returns the path to that binary.
  */
 export function _findHegeld(): string {
-  // HEGEL_CMD override
-  const override = process.env[HEGEL_CMD_ENV];
+  // HEGEL_SERVER_COMMAND override
+  const override = process.env[HEGEL_SERVER_COMMAND_ENV];
   if (override !== undefined) {
     return override;
   }

--- a/src/session.ts
+++ b/src/session.ts
@@ -16,36 +16,87 @@ import { Connection } from "./connection.js";
 import { Client } from "./runner.js";
 
 // ---------------------------------------------------------------------------
+// Pinned hegel-core version
+// ---------------------------------------------------------------------------
+
+/** The hegel-core commit this SDK is designed to work with. */
+const HEGEL_VERSION = "6e327df2dd42553de12ace94cfbddfbbd9e4bf50";
+
+const HEGEL_CMD_ENV = "HEGEL_CMD";
+
+const HEGEL_DIR = ".hegel";
+const VENV_DIR = path.join(HEGEL_DIR, "venv");
+const VERSION_FILE = path.join(VENV_DIR, "hegel-version");
+const HEGEL_BIN = path.join(VENV_DIR, "bin", "hegel");
+
+function hegelPipSpec(): string {
+  return `hegel @ git+ssh://git@github.com/antithesishq/hegel-core.git@${HEGEL_VERSION}`;
+}
+
+let cachedHegelPath: string | null = null;
+
+function ensureHegelInstalled(): string {
+  // Check cached version
+  try {
+    const cached = fs.readFileSync(VERSION_FILE, "utf-8").trim();
+    if (cached === HEGEL_VERSION && fs.existsSync(HEGEL_BIN)) {
+      return HEGEL_BIN;
+    }
+  } catch {
+    // Version file doesn't exist, need to install
+  }
+
+  fs.mkdirSync(HEGEL_DIR, { recursive: true });
+
+  process.stderr.write(`Installing hegel (${HEGEL_VERSION.slice(0, 12)}) into ${VENV_DIR}...\n`);
+
+  childProcess.execSync(`uv venv --clear "${VENV_DIR}"`, {
+    stdio: ["ignore", "inherit", "inherit"],
+  });
+
+  try {
+    childProcess.execSync(`uv pip install --python "${VENV_DIR}/bin/python" "${hegelPipSpec()}"`, {
+      stdio: ["ignore", "inherit", "inherit"],
+    });
+  } catch {
+    throw new Error(
+      `Failed to install hegel (version: ${HEGEL_VERSION}). ` +
+        `Set ${HEGEL_CMD_ENV} to a hegel binary path to skip installation.`,
+    );
+  }
+
+  if (!fs.existsSync(HEGEL_BIN)) {
+    throw new Error(`hegel not found at ${HEGEL_BIN} after installation`);
+  }
+
+  fs.writeFileSync(VERSION_FILE, HEGEL_VERSION);
+
+  return HEGEL_BIN;
+}
+
+// ---------------------------------------------------------------------------
 // Binary discovery
 // ---------------------------------------------------------------------------
 
 /**
  * Locate the hegel binary.
  *
- * Search order:
- * 1. `.venv/bin/hegel` relative to the current working directory
- * 2. `hegel` on the system PATH
- * 3. Fallback: `"python3 -m hegel"`
+ * If `HEGEL_CMD` is set, uses that path directly (the user is responsible
+ * for providing the right binary).
+ *
+ * Otherwise, ensures hegel is installed in `.hegel/venv` at the version
+ * specified by `HEGEL_VERSION` and returns the path to that binary.
  */
 export function _findHegeld(): string {
-  // 1. Check .venv/bin/hegel relative to cwd (typical project setup)
-  const venvHegel = path.join(process.cwd(), ".venv", "bin", "hegel");
-  if (fs.existsSync(venvHegel)) {
-    return venvHegel;
+  // HEGEL_CMD override
+  const override = process.env[HEGEL_CMD_ENV];
+  if (override !== undefined) {
+    return override;
   }
 
-  // 2. Search PATH directories
-  const pathEnv = process.env["PATH"] ?? "";
-  for (const dir of pathEnv.split(path.delimiter)) {
-    if (!dir) continue;
-    const candidate = path.join(dir, "hegel");
-    if (fs.existsSync(candidate)) {
-      return candidate;
-    }
-  }
-
-  // 3. Fallback
-  return "python3 -m hegel";
+  if (cachedHegelPath) return cachedHegelPath;
+  cachedHegelPath = ensureHegelInstalled();
+  return cachedHegelPath;
 }
 
 // ---------------------------------------------------------------------------
@@ -99,11 +150,8 @@ export class HegelSession {
     const socketPath = path.join(this._tempDir, "hegel.sock");
 
     const hegelCmd = _findHegeld();
-    const cmdParts = hegelCmd.split(" ");
-    const binary = cmdParts[0]!;
-    const args = [...cmdParts.slice(1), socketPath];
 
-    this._process = childProcess.spawn(binary, args, {
+    this._process = childProcess.spawn(hegelCmd, [socketPath], {
       stdio: ["ignore", "pipe", "pipe"],
     });
 

--- a/src/session.ts
+++ b/src/session.ts
@@ -156,9 +156,17 @@ export class HegelSession {
 
     const hegelCmd = _findHegeld();
 
+    // Log server output to .hegel/server.log
+    const hegelLogDir = path.join(process.cwd(), HEGEL_DIR);
+    fs.mkdirSync(hegelLogDir, { recursive: true });
+    const logFd = fs.openSync(path.join(hegelLogDir, "server.log"), "a");
+
     this._process = childProcess.spawn(hegelCmd, [socketPath], {
-      stdio: ["ignore", "pipe", "pipe"],
+      stdio: ["ignore", logFd, logFd],
+      env: { ...process.env, PYTHONUNBUFFERED: "1" },
     });
+
+    fs.closeSync(logFd);
 
     // Wait up to 50 × 100 ms = 5 s for the socket to appear and accept
     let connected = false;

--- a/src/session.ts
+++ b/src/session.ts
@@ -35,6 +35,11 @@ function hegelPipSpec(): string {
 
 let cachedHegelPath: string | null = null;
 
+/** @internal Reset cached hegel path (for testing only). */
+export function _resetCachedHegelPath(): void {
+  cachedHegelPath = null;
+}
+
 function ensureHegelInstalled(): string {
   // Check cached version
   try {

--- a/src/session.ts
+++ b/src/session.ts
@@ -20,7 +20,7 @@ import { Client } from "./runner.js";
 // ---------------------------------------------------------------------------
 
 /** The hegel-core commit this SDK is designed to work with. */
-const HEGEL_VERSION = "6e327df2dd42553de12ace94cfbddfbbd9e4bf50";
+const HEGEL_VERSION = "v0.3.3";
 
 const HEGEL_CMD_ENV = "HEGEL_CMD";
 
@@ -53,7 +53,7 @@ function ensureHegelInstalled(): string {
 
   fs.mkdirSync(HEGEL_DIR, { recursive: true });
 
-  process.stderr.write(`Installing hegel (${HEGEL_VERSION.slice(0, 12)}) into ${VENV_DIR}...\n`);
+  process.stderr.write(`Installing hegel (${HEGEL_VERSION}) into ${VENV_DIR}...\n`);
 
   childProcess.execSync(`uv venv --clear "${VENV_DIR}"`, {
     stdio: ["ignore", "inherit", "inherit"],

--- a/tests/session.test.ts
+++ b/tests/session.test.ts
@@ -49,14 +49,14 @@ vi.mock("node:net", async (importOriginal) => {
 // ---------------------------------------------------------------------------
 
 describe("_findHegeld", () => {
-  const origHegelCmd = process.env["HEGEL_CMD"];
+  const origHegelServerCommand = process.env["HEGEL_SERVER_COMMAND"];
 
   afterEach(() => {
-    // Restore HEGEL_CMD
-    if (origHegelCmd !== undefined) {
-      process.env["HEGEL_CMD"] = origHegelCmd;
+    // Restore HEGEL_SERVER_COMMAND
+    if (origHegelServerCommand !== undefined) {
+      process.env["HEGEL_SERVER_COMMAND"] = origHegelServerCommand;
     } else {
-      delete process.env["HEGEL_CMD"];
+      delete process.env["HEGEL_SERVER_COMMAND"];
     }
     _resetCachedHegelPath();
     vi.mocked(fs.existsSync).mockRestore();
@@ -66,20 +66,20 @@ describe("_findHegeld", () => {
     vi.mocked(childProcess.execSync).mockRestore();
   });
 
-  it("returns HEGEL_CMD when set", () => {
-    process.env["HEGEL_CMD"] = "/usr/local/bin/my-hegel";
+  it("returns HEGEL_SERVER_COMMAND when set", () => {
+    process.env["HEGEL_SERVER_COMMAND"] = "/usr/local/bin/my-hegel";
     const result = _findHegeld();
     expect(result).toBe("/usr/local/bin/my-hegel");
   });
 
-  it("returns empty string HEGEL_CMD when set to empty", () => {
-    process.env["HEGEL_CMD"] = "";
+  it("returns empty string HEGEL_SERVER_COMMAND when set to empty", () => {
+    process.env["HEGEL_SERVER_COMMAND"] = "";
     const result = _findHegeld();
     expect(result).toBe("");
   });
 
   it("throws when uv pip install fails", () => {
-    delete process.env["HEGEL_CMD"];
+    delete process.env["HEGEL_SERVER_COMMAND"];
     vi.mocked(fs.readFileSync).mockImplementation(() => {
       throw new Error("ENOENT");
     });
@@ -94,7 +94,7 @@ describe("_findHegeld", () => {
   });
 
   it("throws when hegel binary not found after install", () => {
-    delete process.env["HEGEL_CMD"];
+    delete process.env["HEGEL_SERVER_COMMAND"];
     vi.mocked(fs.readFileSync).mockImplementation(() => {
       throw new Error("ENOENT");
     });
@@ -241,21 +241,21 @@ describe("HegelSession._cleanup", () => {
 // ---------------------------------------------------------------------------
 
 describe("HegelSession timeout", () => {
-  const origHegelCmd = process.env["HEGEL_CMD"];
+  const origHegelServerCommand = process.env["HEGEL_SERVER_COMMAND"];
 
   beforeEach(() => {
     vi.useFakeTimers();
-    // Set HEGEL_CMD so _findHegeld() skips ensureHegelInstalled()
-    process.env["HEGEL_CMD"] = "/usr/bin/false";
+    // Set HEGEL_SERVER_COMMAND so _findHegeld() skips ensureHegelInstalled()
+    process.env["HEGEL_SERVER_COMMAND"] = "/usr/bin/false";
   });
 
   afterEach(() => {
     vi.useRealTimers();
-    // Restore HEGEL_CMD
-    if (origHegelCmd !== undefined) {
-      process.env["HEGEL_CMD"] = origHegelCmd;
+    // Restore HEGEL_SERVER_COMMAND
+    if (origHegelServerCommand !== undefined) {
+      process.env["HEGEL_SERVER_COMMAND"] = origHegelServerCommand;
     } else {
-      delete process.env["HEGEL_CMD"];
+      delete process.env["HEGEL_SERVER_COMMAND"];
     }
     vi.mocked(fs.existsSync).mockRestore();
     vi.mocked(fs.mkdtempSync).mockRestore();

--- a/tests/session.test.ts
+++ b/tests/session.test.ts
@@ -19,6 +19,9 @@ vi.mock("node:fs", async (importOriginal) => {
   return {
     ...actual,
     existsSync: vi.fn(actual.existsSync),
+    readFileSync: vi.fn(actual.readFileSync),
+    writeFileSync: vi.fn(actual.writeFileSync),
+    mkdirSync: vi.fn(actual.mkdirSync),
     mkdtempSync: vi.fn(actual.mkdtempSync),
     rmSync: vi.fn(actual.rmSync),
   };
@@ -29,6 +32,7 @@ vi.mock("node:child_process", async (importOriginal) => {
   return {
     ...actual,
     spawn: vi.fn(actual.spawn),
+    execSync: vi.fn(actual.execSync),
   };
 });
 
@@ -45,60 +49,32 @@ vi.mock("node:net", async (importOriginal) => {
 // ---------------------------------------------------------------------------
 
 describe("_findHegeld", () => {
+  const origHegelCmd = process.env["HEGEL_CMD"];
+
   afterEach(() => {
+    // Restore HEGEL_CMD
+    if (origHegelCmd !== undefined) {
+      process.env["HEGEL_CMD"] = origHegelCmd;
+    } else {
+      delete process.env["HEGEL_CMD"];
+    }
     vi.mocked(fs.existsSync).mockRestore();
+    vi.mocked(fs.readFileSync).mockRestore();
+    vi.mocked(fs.writeFileSync).mockRestore();
+    vi.mocked(fs.mkdirSync).mockRestore();
+    vi.mocked(childProcess.execSync).mockRestore();
   });
 
-  it("returns .venv/bin/hegel when it exists in cwd", () => {
-    vi.mocked(fs.existsSync).mockImplementation((p) => {
-      return String(p).includes(".venv") && String(p).endsWith("hegel");
-    });
+  it("returns HEGEL_CMD when set", () => {
+    process.env["HEGEL_CMD"] = "/usr/local/bin/my-hegel";
     const result = _findHegeld();
-    expect(result).toContain("hegel");
-    expect(result).toContain(".venv");
+    expect(result).toBe("/usr/local/bin/my-hegel");
   });
 
-  it("returns hegel from PATH when .venv not found", () => {
-    const origPath = process.env["PATH"];
-    process.env["PATH"] =
-      "/usr/local/bin" + (process.platform === "win32" ? ";" : ":") + "/usr/bin";
-    vi.mocked(fs.existsSync).mockImplementation((p) => {
-      const s = String(p);
-      // .venv/bin/hegel does NOT exist, but /usr/local/bin/hegel does
-      return !s.includes(".venv") && s.endsWith("hegel");
-    });
+  it("returns empty string HEGEL_CMD when set to empty", () => {
+    process.env["HEGEL_CMD"] = "";
     const result = _findHegeld();
-    expect(result).toContain("hegel");
-    expect(result).not.toContain(".venv");
-    process.env["PATH"] = origPath;
-  });
-
-  it("falls back to python3 -m hegel when not found anywhere", () => {
-    vi.mocked(fs.existsSync).mockReturnValue(false);
-    const result = _findHegeld();
-    expect(result).toBe("python3 -m hegel");
-  });
-
-  it("handles undefined PATH (falls back to python3 -m hegel)", () => {
-    const origPath = process.env["PATH"];
-    delete process.env["PATH"];
-    vi.mocked(fs.existsSync).mockReturnValue(false);
-    const result = _findHegeld();
-    expect(result).toBe("python3 -m hegel");
-    process.env["PATH"] = origPath;
-  });
-
-  it("skips empty PATH entries", () => {
-    const origPath = process.env["PATH"];
-    // PATH with a leading colon produces an empty entry
-    process.env["PATH"] = ":/usr/local/bin";
-    vi.mocked(fs.existsSync).mockImplementation((p) => {
-      const s = String(p);
-      return !s.includes(".venv") && s.endsWith("hegel");
-    });
-    const result = _findHegeld();
-    expect(result).toContain("hegel");
-    process.env["PATH"] = origPath;
+    expect(result).toBe("");
   });
 });
 

--- a/tests/session.test.ts
+++ b/tests/session.test.ts
@@ -214,12 +214,22 @@ describe("HegelSession._cleanup", () => {
 // ---------------------------------------------------------------------------
 
 describe("HegelSession timeout", () => {
+  const origHegelCmd = process.env["HEGEL_CMD"];
+
   beforeEach(() => {
     vi.useFakeTimers();
+    // Set HEGEL_CMD so _findHegeld() skips ensureHegelInstalled()
+    process.env["HEGEL_CMD"] = "/usr/bin/false";
   });
 
   afterEach(() => {
     vi.useRealTimers();
+    // Restore HEGEL_CMD
+    if (origHegelCmd !== undefined) {
+      process.env["HEGEL_CMD"] = origHegelCmd;
+    } else {
+      delete process.env["HEGEL_CMD"];
+    }
     vi.mocked(fs.existsSync).mockRestore();
     vi.mocked(fs.mkdtempSync).mockRestore();
     vi.mocked(fs.rmSync).mockRestore();

--- a/tests/session.test.ts
+++ b/tests/session.test.ts
@@ -4,7 +4,7 @@ import * as net from "node:net";
 import { EventEmitter } from "node:events";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { HegelSession, hegel, runHegelTest } from "hegel";
-import { _findHegeld } from "../src/session.js";
+import { _findHegeld, _resetCachedHegelPath } from "../src/session.js";
 import { generateFromSchema, _testContextStorage } from "../src/runner.js";
 
 // ---------------------------------------------------------------------------
@@ -58,6 +58,7 @@ describe("_findHegeld", () => {
     } else {
       delete process.env["HEGEL_CMD"];
     }
+    _resetCachedHegelPath();
     vi.mocked(fs.existsSync).mockRestore();
     vi.mocked(fs.readFileSync).mockRestore();
     vi.mocked(fs.writeFileSync).mockRestore();
@@ -75,6 +76,32 @@ describe("_findHegeld", () => {
     process.env["HEGEL_CMD"] = "";
     const result = _findHegeld();
     expect(result).toBe("");
+  });
+
+  it("throws when uv pip install fails", () => {
+    delete process.env["HEGEL_CMD"];
+    vi.mocked(fs.readFileSync).mockImplementation(() => {
+      throw new Error("ENOENT");
+    });
+    vi.mocked(fs.mkdirSync).mockReturnValue(undefined as unknown as string);
+    vi.mocked(childProcess.execSync).mockImplementation((cmd) => {
+      if (typeof cmd === "string" && cmd.includes("uv pip")) {
+        throw new Error("pip install failed");
+      }
+      return Buffer.from("");
+    });
+    expect(() => _findHegeld()).toThrow("Failed to install hegel");
+  });
+
+  it("throws when hegel binary not found after install", () => {
+    delete process.env["HEGEL_CMD"];
+    vi.mocked(fs.readFileSync).mockImplementation(() => {
+      throw new Error("ENOENT");
+    });
+    vi.mocked(fs.mkdirSync).mockReturnValue(undefined as unknown as string);
+    vi.mocked(childProcess.execSync).mockReturnValue(Buffer.from(""));
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+    expect(() => _findHegeld()).toThrow("hegel not found at");
   });
 });
 


### PR DESCRIPTION
## Summary

- Manage the hegel server binary via a pinned `.hegel/venv` virtualenv instead of expecting it on PATH, auto-installing hegel-core at a pinned version on first use
- Pin `HEGEL_VERSION` to a release tag (e.g. `v0.3.3`) instead of a commit hash, with a `just update-hegel-core-version` recipe to bump it manually
- Redirect hegel server stdout/stderr to `.hegel/server.log` (append mode, `PYTHONUNBUFFERED=1`) for easier debugging
- Rename `HEGEL_CMD` env var to `HEGEL_SERVER_COMMAND` to align with hegel-rust naming convention
- Add tests for install error paths to achieve 100% coverage
- CI fixes: add RELEASE.md, fix conformance test deps, fix timeout test, remove `environment: ci` declarations, suppress zizmor `secrets-outside-env` via `.github/zizmor.yml`
- Release workflow fixes: use app token with hegel-core repo access for version pinning, simplify release notes

## Test plan

- [ ] `just check` passes
- [ ] Server log appears at `.hegel/server.log` after test run
- [ ] `HEGEL_SERVER_COMMAND=/path/to/hegel` overrides auto-install

🤖 Generated with [Claude Code](https://claude.com/claude-code)