### PR TITLE
Log server output to .hegel/server.log

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -103,9 +103,17 @@ export class HegelSession {
     const binary = cmdParts[0]!;
     const args = [...cmdParts.slice(1), socketPath];
 
+    // Log server output to .hegel/server.log
+    const hegelDir = path.join(process.cwd(), ".hegel");
+    fs.mkdirSync(hegelDir, { recursive: true });
+    const logFd = fs.openSync(path.join(hegelDir, "server.log"), "a");
+
     this._process = childProcess.spawn(binary, args, {
-      stdio: ["ignore", "pipe", "pipe"],
+      stdio: ["ignore", logFd, logFd],
+      env: { ...process.env, PYTHONUNBUFFERED: "1" },
     });
+
+    fs.closeSync(logFd);
 
     // Wait up to 50 × 100 ms = 5 s for the socket to appear and accept
     let connected = false;


### PR DESCRIPTION
## Summary

- Redirect hegel server subprocess stdout/stderr to `.hegel/server.log` (append mode) instead of inheriting parent's stdio
- Set `PYTHONUNBUFFERED=1` so log output is written promptly
- Open the log file descriptor and pass it to `spawn()` stdio config

Matches the approach taken in https://github.com/antithesishq/hegel-rust/pull/45.

## Test plan

- [ ] Run tests and verify they still pass
- [ ] Check that `.hegel/server.log` is created and contains server output

🤖 Generated with [Claude Code](https://claude.com/claude-code)