### PR TITLE
Add CLAUDE.local.md and .claude/local/ to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 .claude/plan.md
 .claude/settings.local.json
+.claude/local/
+CLAUDE.local.md
 
 .venv/
 .hegel/


### PR DESCRIPTION
<details><summary>Claude-written description</summary>

Add gitignore entries for `CLAUDE.local.md` and `.claude/local/` to standardize Claude-related gitignore patterns across all hegel repos. This allows developers to use `CLAUDE.local.md` for personal workflow preferences and `.claude/local/` for local skills and other personal Claude config without accidentally committing them.

</details>