### PR TITLE
claude: accept readonly arrays in sampledFrom and category options

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,6 @@
+RELEASE_TYPE: patch
+
+`sampledFrom` and the `categories` / `excludeCategories` options on `text` /
+`characters` now accept `readonly` arrays. This lets callers pass a
+`const`-asserted tuple (e.g. `["a", "b"] as const`) directly without a
+`[...arr]` workaround.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,6 +1,3 @@
 RELEASE_TYPE: patch
 
-`sampledFrom` and the `categories` / `excludeCategories` options on `text` /
-`characters` now accept `readonly` arrays. This lets callers pass a
-`const`-asserted tuple (e.g. `["a", "b"] as const`) directly without a
-`[...arr]` workaround.
+Loosen the type of `sampledFrom` and `text({categories: ...})` to accept `readonly` arrays.

--- a/src/generators/combinators.ts
+++ b/src/generators/combinators.ts
@@ -31,7 +31,7 @@ class SampledFromGenerator<T> extends Generator<T> {
   private readonly elements: T[];
   private readonly schema: Record<string, unknown>;
 
-  constructor(elements: T[]) {
+  constructor(elements: readonly T[]) {
     super();
     if (elements.length === 0) {
       throw new Error("sampledFrom requires at least one element");
@@ -51,7 +51,7 @@ class SampledFromGenerator<T> extends Generator<T> {
 }
 
 /** Pick from a fixed list of values. Panics if empty. */
-export function sampledFrom<T>(elements: T[]): Generator<T> {
+export function sampledFrom<T>(elements: readonly T[]): Generator<T> {
   return new SampledFromGenerator(elements);
 }
 

--- a/src/generators/strings.ts
+++ b/src/generators/strings.ts
@@ -24,9 +24,9 @@ export interface CharacterFilterOptions {
   /** Maximum Unicode codepoint (inclusive). */
   maxCodepoint?: number;
   /** Include only characters from these Unicode general categories (e.g. ["L", "Nd"]). */
-  categories?: string[];
+  categories?: readonly string[];
   /** Exclude characters from these Unicode general categories. */
-  excludeCategories?: string[];
+  excludeCategories?: readonly string[];
   /** Always include these specific characters. */
   includeCharacters?: string;
   /** Always exclude these specific characters. */

--- a/tests/showcase.test.ts
+++ b/tests/showcase.test.ts
@@ -135,7 +135,7 @@ test(
     (tc) => {
       const colors = ["red", "green", "blue"] as const;
       const colorSet = new Set<string>(colors);
-      const v = tc.draw(gs.sampledFrom([...colors]));
+      const v = tc.draw(gs.sampledFrom(colors));
       if (!colorSet.has(v)) {
         throw new Error(`Unexpected value: ${v}`);
       }


### PR DESCRIPTION
<details><summary>Claude-written description</summary>

`sampledFrom` and the `categories` / `excludeCategories` options on `text` / `characters` previously took mutable `T[]` / `string[]`. Because `T[]` is a subtype of `readonly T[]` (not the other way around), passing a `const`-asserted tuple — the idiomatic way to derive a string-literal union — failed to typecheck:

```ts
const lengthUnits = ["meter", "kilometer", "foot"] as const;
type LengthUnit = typeof lengthUnits[number];
gs.sampledFrom(lengthUnits); // error: readonly array not assignable to T[]
```

Users had to work around this with `gs.sampledFrom([...lengthUnits])`. This PR widens the parameter types to `readonly T[]` so the workaround is no longer needed. Both functions already treat the input as read-only at runtime (`sampledFrom` makes a defensive copy; `categories` is dropped into a schema dict).

Changes:
- `SampledFromGenerator` constructor and `sampledFrom` accept `readonly T[]`.
- `CharacterFilterOptions.categories` / `excludeCategories` accept `readonly string[]`.
- Updated one showcase test that used the `[...arr]` workaround.

</details>
