### PR TITLE
gitignore: whitelist .claude files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
-.claude/plan.md
-.claude/settings.local.json
-.claude/local/
+# whitelist .claude files, rather than blacklist. Some local claude files
+# (skills, agents) have to live in .claude - as opposed to eg CLAUDE.local.md,
+# which we gitignore at the top level.
+.claude/*
+!.claude/CLAUDE.md
 CLAUDE.local.md
 
 .venv/


### PR DESCRIPTION
Switch the .claude/ section of .gitignore to a whitelist instead of blacklist. Local files (skills, agents, settings, plans, etc.) inside .claude/ stay untracked by default; only explicitly-tracked files like .claude/CLAUDE.md are committed.

The motivation is that some shared claude files (skills, agents) have to live in .claude/, but we want to be able to drop local-only files in there without them showing up in git status. A whitelist handles both cleanly. CLAUDE.local.md continues to be gitignored at the top level.