### PR TITLE
claude: whitelist .claude in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
-.claude/plan.md
-.claude/settings.local.json
-.claude/local/
+# whitelist .claude files, rather than blacklist. Some local claude files
+# (skills, agents) have to live in .claude - as opposed to eg CLAUDE.local.md,
+# which we gitignore at the top level.
+.claude/*
+!.claude/CLAUDE.md
 CLAUDE.local.md
 
 .venv/


### PR DESCRIPTION
<details><summary>Claude-written description</summary>

Switch the `.claude/` section of `.gitignore` from a blacklist (`.claude/plan.md`, `.claude/settings.local.json`, `.claude/local/`) to a whitelist. Local files (skills, agents, settings, plans) inside `.claude/` are now untracked by default; only explicitly-allowed files (`.claude/CLAUDE.md`) are committed. Top-level `CLAUDE.local.md` continues to be gitignored at the top level.

</details>
