### PR TITLE
claude: port getting-started tutorial into package docs and trim public API

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,17 @@
+RELEASE_TYPE: patch
+
+This release makes `generators` reachable as a namespace from `@hegeldev/hegel`:
+
+```typescript
+// A
+import * as hegel from "@hegeldev/hegel";
+hegel.generators.integers()
+
+// B, still works as before:
+import * as gs from "@hegeldev/hegel/generators";
+gs.integers()
+```
+
+We still recommend option B.
+
+This release also removes a number of private APIs from the public exports of `@hegeldev/hegel`.

--- a/src/generators/core.ts
+++ b/src/generators/core.ts
@@ -4,13 +4,13 @@
  * @packageDocumentation
  */
 
-import { TestCase, Labels, generateRaw, type GeneratorLike } from "../testCase.js";
+import { TestCase, Labels, generateRaw } from "../testCase.js";
 
 /**
  * Base class for all generators. Generators produce values of type T
  * synchronously by communicating with the hegel server.
  */
-export abstract class Generator<T> implements GeneratorLike<T> {
+export abstract class Generator<T> {
   /** @internal */
   abstract doDraw(tc: TestCase): T;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,24 +1,229 @@
 /**
- * Hegel property-based testing library for TypeScript.
+ * Hegel is a property-based testing library for TypeScript. Hegel is based on
+ * [Hypothesis](https://github.com/hypothesisworks/hypothesis), using the
+ * [Hegel protocol](https://hegel.dev/).
  *
- * The root entry point exposes the test runner, settings, and core types.
- * Generators live under `hegel/generators`.
+ * # Getting started
+ *
+ * This guide walks you through the basics of installing Hegel and writing your
+ * first tests.
+ *
+ * ## Install Hegel
+ *
+ * Add `@hegeldev/hegel` to your project as a dev dependency:
+ *
+ * ```bash
+ * npm install --save-dev @hegeldev/hegel
+ * ```
+ *
+ * Hegel requires Node 16+. Bun and Deno are not currently supported.
+ *
+ * ## Write your first test
+ *
+ * You're now ready to write your first test. We'll use
+ * [Vitest](https://vitest.dev/) as the test runner for the purposes of this
+ * guide. Create a new test file:
+ *
+ * ```ts
+ * import { test } from "vitest";
+ * import * as hegel from "@hegeldev/hegel";
+ * import * as gs from "@hegeldev/hegel/generators";
+ *
+ * test(
+ *   "integer self equality",
+ *   hegel.test((tc) => {
+ *     const n = tc.draw(gs.integers());
+ *     if (n !== n) {
+ *       throw new Error("integer was not equal to itself");
+ *     }
+ *   }),
+ * );
+ * ```
+ *
+ * Now run the test using `npx vitest run`. You should see that this test
+ * passes.
+ *
+ * Let's look at what's happening in more detail. {@link test} runs your test
+ * many times (100, by default). The test function receives a {@link TestCase},
+ * which provides a {@link TestCase.draw | draw} method for drawing different
+ * values. This test draws a random integer and checks that it should be equal
+ * to itself.
+ *
+ * Next, try a test that fails:
+ *
+ * ```ts
+ * test(
+ *   "integers always below 50",
+ *   hegel.test((tc) => {
+ *     const n = tc.draw(gs.integers());
+ *     if (n >= 50) {
+ *       throw new Error(`n=${n} is too large`);
+ *     }
+ *   }),
+ * );
+ * ```
+ *
+ * This test asserts that any integer is less than 50, which is obviously
+ * incorrect. Hegel will find a test case that makes this assertion fail, and
+ * then shrink it to find the smallest counterexample — in this case, `n = 50`.
+ *
+ * To fix this test, you can constrain the integers you generate with the
+ * `minValue` and `maxValue` options:
+ *
+ * ```ts
+ * test(
+ *   "bounded integers always below 50",
+ *   hegel.test((tc) => {
+ *     const n = tc.draw(gs.integers({ minValue: 0, maxValue: 49 }));
+ *     if (n >= 50) {
+ *       throw new Error(`n=${n} is too large`);
+ *     }
+ *   }),
+ * );
+ * ```
+ *
+ * Run the test again. It should now pass.
+ *
+ * ## Use generators
+ *
+ * Hegel provides a rich library of generators that you can use out of the box.
+ * There are primitive generators, such as `integers`, `floats`, and `text`,
+ * and combinators that allow you to make generators out of other generators,
+ * such as `arrays` and `maps`.
+ *
+ * For example, you can use `arrays` to generate an array of integers:
+ *
+ * ```ts
+ * test(
+ *   "append increases length",
+ *   hegel.test((tc) => {
+ *     const xs = tc.draw(gs.arrays(gs.integers()));
+ *     const initialLength = xs.length;
+ *     xs.push(tc.draw(gs.integers()));
+ *     if (xs.length <= initialLength) {
+ *       throw new Error("length did not increase");
+ *     }
+ *   }),
+ * );
+ * ```
+ *
+ * This test checks that appending an element to a random array of integers
+ * should always increase its length.
+ *
+ * You can also build composite values out of multiple generators. The simplest
+ * way is to draw fields directly inside the test body:
+ *
+ * ```ts
+ * interface Person {
+ *   age: number;
+ *   name: string;
+ * }
+ *
+ * test(
+ *   "person",
+ *   hegel.test((tc) => {
+ *     const person: Person = {
+ *       age: tc.draw(gs.integers({ minValue: 0, maxValue: 120 })),
+ *       name: tc.draw(gs.text({ minSize: 1, maxSize: 50 })),
+ *     };
+ *     // use person in your test
+ *     void person;
+ *   }),
+ * );
+ * ```
+ *
+ * For composite values you want to reuse across tests, build a generator with
+ * `composite` (imperative — call `tc.draw()` on inner generators inside a
+ * builder function) or `record` (declarative — pass a schema mapping field
+ * names to generators). Both produce a generator that supports `.map()`,
+ * `.filter()`, and `.flatMap()` like any other generator.
+ *
+ * ```ts
+ * const personGen = gs.record({
+ *   age: gs.integers({ minValue: 0, maxValue: 120 }),
+ *   name: gs.text({ minSize: 1, maxSize: 50 }),
+ * });
+ *
+ * test(
+ *   "person via record",
+ *   hegel.test((tc) => {
+ *     const person = tc.draw(personGen);
+ *     void person;
+ *   }),
+ * );
+ * ```
+ *
+ * Note that you can feed the results of one `draw` into subsequent calls — this
+ * is what `composite` is for. For example, say that you extend the `Person`
+ * interface to include a `drivingLicense` boolean field, where the field
+ * depends on `age`:
+ *
+ * ```ts
+ * interface Person {
+ *   age: number;
+ *   name: string;
+ *   drivingLicense: boolean;
+ * }
+ *
+ * const personGen = gs.composite<Person>((tc) => {
+ *   const age = tc.draw(gs.integers({ minValue: 0, maxValue: 120 }));
+ *   const name = tc.draw(gs.text({ minSize: 1, maxSize: 50 }));
+ *   const drivingLicense = age >= 18 ? tc.draw(gs.booleans()) : false;
+ *   return { age, name, drivingLicense };
+ * });
+ * ```
+ *
+ * ## Debug your failing test cases
+ *
+ * Use the {@link TestCase.note | note} method to attach debug information:
+ *
+ * ```ts
+ * test(
+ *   "addition is commutative",
+ *   hegel.test((tc) => {
+ *     const x = tc.draw(gs.integers());
+ *     const y = tc.draw(gs.integers());
+ *     tc.note(`x + y = ${x + y}, y + x = ${y + x}`);
+ *     if (x + y !== y + x) {
+ *       throw new Error("addition is not commutative");
+ *     }
+ *   }),
+ * );
+ * ```
+ *
+ * Notes only appear when Hegel replays the minimal failing example.
+ *
+ * ## Change the number of test cases
+ *
+ * By default Hegel runs 100 test cases. To override this, pass a
+ * {@link Settings} override as the second argument to {@link test}:
+ *
+ * ```ts
+ * test(
+ *   "integers many",
+ *   hegel.test(
+ *     (tc) => {
+ *       const n = tc.draw(gs.integers());
+ *       if (n !== n) {
+ *         throw new Error("integer was not equal to itself");
+ *       }
+ *     },
+ *     { testCases: 500 },
+ *   ),
+ * );
+ * ```
+ *
+ * ## Learning more
+ *
+ * - Browse the `@hegeldev/hegel/generators` module for the full list of
+ *   available generators.
+ * - See {@link Settings} for more configuration settings to customize how
+ *   your test runs.
  *
  * @packageDocumentation
  */
 
-export { TestCase, Collection, Labels, StopTestError, AssumeError } from "./testCase.js";
-export type { GeneratorLike, DataSource } from "./testCase.js";
-export {
-  test,
-  testAsync,
-  Verbosity,
-  HealthCheck,
-  Database,
-  defaultSettings,
-  ServerDataSource,
-} from "./runner.js";
-export type { Settings, TestCaseResult, TestLocation } from "./runner.js";
-export type { Packet } from "./protocol.js";
-export { Connection, Stream } from "./connection.js";
-export { HegelSession, HEGEL_SERVER_VERSION } from "./session.js";
+export * as generators from "./generators/index.js";
+export { TestCase } from "./testCase.js";
+export { test, testAsync, Verbosity, HealthCheck, Database } from "./runner.js";
+export type { Settings } from "./runner.js";

--- a/src/testCase.ts
+++ b/src/testCase.ts
@@ -8,6 +8,8 @@
  */
 
 import { inspect } from "node:util";
+// Type-only import to avoid a runtime cycle: Generator depends on TestCase.
+import type { Generator } from "./generators/core.js";
 
 export class StopTestError extends Error {
   constructor() {
@@ -45,10 +47,6 @@ export const Labels = {
   ENUM_VARIANT: 15,
 } as const;
 
-export interface GeneratorLike<T> {
-  doDraw(tc: TestCase): T;
-}
-
 /**
  * Abstraction over the data backend for a test case.
  *
@@ -84,10 +82,12 @@ export class TestCase {
     return this._dataSource;
   }
 
+  /** @internal */
   get isLastRun(): boolean {
     return this._isLastRun;
   }
 
+  /** @internal */
   get testAborted(): boolean {
     return this._dataSource.testAborted();
   }
@@ -95,7 +95,7 @@ export class TestCase {
   /**
    * Draw a value from a generator.
    */
-  draw<T>(generator: GeneratorLike<T>): T {
+  draw<T>(generator: Generator<T>): T {
     const value = generator.doDraw(this);
     if (this.spanDepth === 0) {
       this.drawCount++;
@@ -104,14 +104,6 @@ export class TestCase {
       }
     }
     return value;
-  }
-
-  /**
-   * Draw a value from a generator without recording it in the output.
-   * Unlike draw(), this does not print the value during the final replay.
-   */
-  drawSilent<T>(generator: GeneratorLike<T>): T {
-    return generator.doDraw(this);
   }
 
   /**
@@ -134,6 +126,7 @@ export class TestCase {
 
   /**
    * Start a shrinking span with the given label.
+   * @internal
    */
   startSpan(label: number): void {
     this.spanDepth++;
@@ -147,6 +140,7 @@ export class TestCase {
 
   /**
    * Stop the current shrinking span.
+   * @internal
    */
   stopSpan(discard = false): void {
     this.spanDepth--;

--- a/tests/collections.test.ts
+++ b/tests/collections.test.ts
@@ -14,7 +14,7 @@ import { describe, test, expect } from "vitest";
 import * as hegel from "@hegeldev/hegel";
 import * as gs from "@hegeldev/hegel/generators";
 
-// hegel.Collection protocol tests use fewer test cases because each test case
+// Collection protocol tests use fewer test cases because each test case
 // involves many server round-trips (one per collection element).
 const FEW = { testCases: 20 };
 

--- a/tests/coverage.test.ts
+++ b/tests/coverage.test.ts
@@ -1,7 +1,7 @@
 /**
  * Tests targeting uncovered code paths, ported from hegel-rust test patterns.
  *
- * Covers: hegel.Collection protocol, composite generator fallbacks, StopTest
+ * Covers: Collection protocol, composite generator fallbacks, StopTest
  * handling via HEGEL_PROTOCOL_TEST_MODE, filter exhaustion, and error paths.
  */
 
@@ -10,13 +10,13 @@ import * as hegel from "@hegeldev/hegel";
 import * as gs from "@hegeldev/hegel/generators";
 
 // ---------------------------------------------------------------------------
-// hegel.Collection protocol via composite generators
-// (When elements don't have asBasic(), arrays/sets/maps use hegel.Collection)
+// Collection protocol via composite generators
+// (When elements don't have asBasic(), arrays/sets/maps use Collection)
 // ---------------------------------------------------------------------------
 
 describe("collection protocol", () => {
   // A composite generator has no schema, so gs.arrays() must use the
-  // hegel.Collection protocol (new_collection / collection_more) instead of
+  // Collection protocol (new_collection / collection_more) instead of
   // sending a list schema to the server.
   const compositeInt = gs.composite((tc) => tc.draw(gs.integers({ minValue: 0, maxValue: 100 })));
 

--- a/tests/datasource.test.ts
+++ b/tests/datasource.test.ts
@@ -1,19 +1,26 @@
 /**
- * Tests using fake hegel.DataSource implementations to exercise code paths in
+ * Tests using fake DataSource implementations to exercise code paths in
  * testCase.ts, generators.ts, and runner.ts that are unreachable through
  * the real hegel server.
  */
 
 import { describe, it, expect, vi } from "vitest";
-import * as hegel from "@hegeldev/hegel";
 import * as gs from "@hegeldev/hegel/generators";
+import {
+  AssumeError,
+  Collection,
+  Labels,
+  StopTestError,
+  TestCase,
+  type DataSource,
+} from "../src/testCase.js";
 import { runTestCase } from "../src/runner.js";
 
 // ---------------------------------------------------------------------------
 // FakeDataSource
 // ---------------------------------------------------------------------------
 
-class FakeDataSource implements hegel.DataSource {
+class FakeDataSource implements DataSource {
   private generates: unknown[];
   private generateIndex = 0;
   private _throwOnStartSpan: boolean;
@@ -45,7 +52,7 @@ class FakeDataSource implements hegel.DataSource {
   generate(schema: Record<string, unknown>): unknown {
     void schema;
     if (this.generateIndex >= this.generates.length) {
-      throw new hegel.StopTestError();
+      throw new StopTestError();
     }
     return this.generates[this.generateIndex++];
   }
@@ -97,33 +104,33 @@ class FakeDataSource implements hegel.DataSource {
 describe("TestCase with fake DataSource", () => {
   it("isLastRun getter returns true when constructed with isLastRun=true", () => {
     const ds = new FakeDataSource({ generates: [42] });
-    const tc = new hegel.TestCase(ds, true);
+    const tc = new TestCase(ds, true);
     expect(tc.isLastRun).toBe(true);
   });
 
   it("isLastRun getter returns false when constructed with isLastRun=false", () => {
     const ds = new FakeDataSource({ generates: [42] });
-    const tc = new hegel.TestCase(ds, false);
+    const tc = new TestCase(ds, false);
     expect(tc.isLastRun).toBe(false);
   });
 
   it("stopSpan catches errors from dataSource.stopSpan", () => {
     const ds = new FakeDataSource({ generates: [42], throwOnStopSpan: true });
-    const tc = new hegel.TestCase(ds, false);
-    tc.startSpan(hegel.Labels.LIST);
+    const tc = new TestCase(ds, false);
+    tc.startSpan(Labels.LIST);
     // stopSpan should NOT throw even though dataSource.stopSpan throws
     expect(() => tc.stopSpan()).not.toThrow();
   });
 
   it("startSpan catches and re-throws errors from dataSource.startSpan", () => {
     const ds = new FakeDataSource({ generates: [42], throwOnStartSpan: true });
-    const tc = new hegel.TestCase(ds, false);
-    expect(() => tc.startSpan(hegel.Labels.LIST)).toThrow("startSpan error");
+    const tc = new TestCase(ds, false);
+    expect(() => tc.startSpan(Labels.LIST)).toThrow("startSpan error");
   });
 
   it("draw logs to stderr on isLastRun=true at spanDepth=0", () => {
     const ds = new FakeDataSource({ generates: [42] });
-    const tc = new hegel.TestCase(ds, true);
+    const tc = new TestCase(ds, true);
     const spy = vi.spyOn(console, "error").mockImplementation(() => {});
     tc.draw(gs.integers());
     expect(spy).toHaveBeenCalledWith(expect.stringContaining("draw_1"));
@@ -132,7 +139,7 @@ describe("TestCase with fake DataSource", () => {
 
   it("note writes to stderr on isLastRun=true", () => {
     const ds = new FakeDataSource({ generates: [] });
-    const tc = new hegel.TestCase(ds, true);
+    const tc = new TestCase(ds, true);
     const spy = vi.spyOn(console, "error").mockImplementation(() => {});
     tc.note("hello");
     expect(spy).toHaveBeenCalledWith("hello");
@@ -141,7 +148,7 @@ describe("TestCase with fake DataSource", () => {
 
   it("note does nothing on isLastRun=false", () => {
     const ds = new FakeDataSource({ generates: [] });
-    const tc = new hegel.TestCase(ds, false);
+    const tc = new TestCase(ds, false);
     const spy = vi.spyOn(console, "error").mockImplementation(() => {});
     tc.note("hello");
     expect(spy).not.toHaveBeenCalled();
@@ -150,32 +157,32 @@ describe("TestCase with fake DataSource", () => {
 
   it("testAborted returns dataSource.testAborted()", () => {
     const ds = new FakeDataSource({ aborted: true });
-    const tc = new hegel.TestCase(ds, false);
+    const tc = new TestCase(ds, false);
     expect(tc.testAborted).toBe(true);
   });
 
   it("assume(false) throws AssumeError", () => {
     const ds = new FakeDataSource();
-    const tc = new hegel.TestCase(ds, false);
-    expect(() => tc.assume(false)).toThrow(hegel.AssumeError);
+    const tc = new TestCase(ds, false);
+    expect(() => tc.assume(false)).toThrow(AssumeError);
   });
 
   it("assume(true) does not throw", () => {
     const ds = new FakeDataSource();
-    const tc = new hegel.TestCase(ds, false);
+    const tc = new TestCase(ds, false);
     expect(() => tc.assume(true)).not.toThrow();
   });
 });
 
 // ---------------------------------------------------------------------------
-// hegel.Collection
+// Collection
 // ---------------------------------------------------------------------------
 
 describe("Collection with fake DataSource", () => {
   it("reject when finished is a no-op", () => {
     const ds = new FakeDataSource({ collectionCounts: 0 });
-    const tc = new hegel.TestCase(ds, false);
-    const col = new hegel.Collection(tc, 0);
+    const tc = new TestCase(ds, false);
+    const col = new Collection(tc, 0);
     expect(col.more()).toBe(false);
     // reject after finished should not throw
     col.reject("should be no-op");
@@ -183,16 +190,16 @@ describe("Collection with fake DataSource", () => {
 
   it("more when already finished returns false", () => {
     const ds = new FakeDataSource({ collectionCounts: 0 });
-    const tc = new hegel.TestCase(ds, false);
-    const col = new hegel.Collection(tc, 0);
+    const tc = new TestCase(ds, false);
+    const col = new Collection(tc, 0);
     expect(col.more()).toBe(false);
     expect(col.more()).toBe(false);
   });
 
   it("collection with elements", () => {
     const ds = new FakeDataSource({ collectionCounts: 2, generates: [10, 20] });
-    const tc = new hegel.TestCase(ds, false);
-    const col = new hegel.Collection(tc, 0);
+    const tc = new TestCase(ds, false);
+    const col = new Collection(tc, 0);
     expect(col.more()).toBe(true);
     expect(col.more()).toBe(true);
     expect(col.more()).toBe(false);
@@ -202,11 +209,11 @@ describe("Collection with fake DataSource", () => {
     const ds = new FakeDataSource({ collectionCounts: 1 });
     // Override collectionMore to throw
     ds.collectionMore = () => {
-      throw new hegel.StopTestError();
+      throw new StopTestError();
     };
-    const tc = new hegel.TestCase(ds, false);
-    const col = new hegel.Collection(tc, 0);
-    expect(() => col.more()).toThrow(hegel.StopTestError);
+    const tc = new TestCase(ds, false);
+    const col = new Collection(tc, 0);
+    expect(() => col.more()).toThrow(StopTestError);
     // After error, more() returns false without calling dataSource again
     expect(col.more()).toBe(false);
   });
@@ -219,7 +226,7 @@ describe("Collection with fake DataSource", () => {
 describe("MappedGenerator with fake DataSource", () => {
   it("map on BasicGenerator uses optimized asBasic() path", () => {
     const ds = new FakeDataSource({ generates: [5] });
-    const tc = new hegel.TestCase(ds, false);
+    const tc = new TestCase(ds, false);
     const gen = gs.integers().map((x) => x * 2);
     // This exercises MappedGenerator.doDraw -> asBasic() returns non-null
     expect(tc.draw(gen)).toBe(10);
@@ -227,7 +234,7 @@ describe("MappedGenerator with fake DataSource", () => {
 
   it("map on composite returns null from asBasic()", () => {
     const ds = new FakeDataSource({ generates: [7] });
-    const tc = new hegel.TestCase(ds, false);
+    const tc = new TestCase(ds, false);
     const gen = gs.composite((inner) => inner.draw(gs.integers())).map((x) => x + 1);
     // MappedGenerator.asBasic() returns null, uses span-based path
     expect(tc.draw(gen)).toBe(8);
@@ -241,31 +248,31 @@ describe("MappedGenerator with fake DataSource", () => {
 describe("Generator parse error paths", () => {
   it("binary parseBytes throws on non-bytes", () => {
     const ds = new FakeDataSource({ generates: ["not bytes"] });
-    const tc = new hegel.TestCase(ds, false);
+    const tc = new TestCase(ds, false);
     expect(() => tc.draw(gs.binary())).toThrow("Expected bytes");
   });
 
   it("arrays parse throws on non-array", () => {
     const ds = new FakeDataSource({ generates: ["not array"] });
-    const tc = new hegel.TestCase(ds, false);
+    const tc = new TestCase(ds, false);
     expect(() => tc.draw(gs.arrays(gs.integers()))).toThrow("Expected array");
   });
 
   it("sets parse throws on non-array", () => {
     const ds = new FakeDataSource({ generates: ["not array"] });
-    const tc = new hegel.TestCase(ds, false);
+    const tc = new TestCase(ds, false);
     expect(() => tc.draw(gs.sets(gs.integers()))).toThrow("Expected array");
   });
 
   it("maps parse throws on non-array", () => {
     const ds = new FakeDataSource({ generates: ["not array"] });
-    const tc = new hegel.TestCase(ds, false);
+    const tc = new TestCase(ds, false);
     expect(() => tc.draw(gs.maps(gs.integers(), gs.integers()))).toThrow("Expected array");
   });
 
   it("maps parse throws on invalid entry", () => {
     const ds = new FakeDataSource({ generates: [["not a pair"]] });
-    const tc = new hegel.TestCase(ds, false);
+    const tc = new TestCase(ds, false);
     expect(() => tc.draw(gs.maps(gs.integers(), gs.integers()))).toThrow(
       "Expected [key, value] pair",
     );
@@ -273,19 +280,19 @@ describe("Generator parse error paths", () => {
 
   it("oneOf parse throws on non-array", () => {
     const ds = new FakeDataSource({ generates: ["not array"] });
-    const tc = new hegel.TestCase(ds, false);
+    const tc = new TestCase(ds, false);
     expect(() => tc.draw(gs.oneOf(gs.integers(), gs.booleans()))).toThrow("Expected array");
   });
 
   it("optional parse throws on non-array", () => {
     const ds = new FakeDataSource({ generates: ["not array"] });
-    const tc = new hegel.TestCase(ds, false);
+    const tc = new TestCase(ds, false);
     expect(() => tc.draw(gs.optional(gs.integers()))).toThrow("Expected array");
   });
 
   it("tuples parse throws on non-array", () => {
     const ds = new FakeDataSource({ generates: ["not array"] });
-    const tc = new hegel.TestCase(ds, false);
+    const tc = new TestCase(ds, false);
     expect(() => tc.draw(gs.tuples(gs.integers(), gs.integers()))).toThrow("Expected array");
   });
 });
@@ -309,14 +316,14 @@ describe("text and characters with alphabet", () => {
 
   it("text generator parses result as string", () => {
     const ds = new FakeDataSource({ generates: [42] });
-    const tc = new hegel.TestCase(ds, false);
+    const tc = new TestCase(ds, false);
     const result = tc.draw(gs.text());
     expect(result).toBe("42");
   });
 
   it("characters generator parses result as string", () => {
     const ds = new FakeDataSource({ generates: ["a"] });
-    const tc = new hegel.TestCase(ds, false);
+    const tc = new TestCase(ds, false);
     const result = tc.draw(gs.characters());
     expect(result).toBe("a");
   });
@@ -382,14 +389,14 @@ describe("optional parse paths", () => {
 
   it("optional returns null when index is 0", () => {
     const ds = new FakeDataSource({ generates: [[0, null]] });
-    const tc = new hegel.TestCase(ds, false);
+    const tc = new TestCase(ds, false);
     const result = tc.draw(gs.optional(gs.integers()));
     expect(result).toBeNull();
   });
 
   it("optional returns value when index is 1", () => {
     const ds = new FakeDataSource({ generates: [[1, 42]] });
-    const tc = new hegel.TestCase(ds, false);
+    const tc = new TestCase(ds, false);
     const result = tc.draw(gs.optional(gs.integers()));
     expect(result).toBe(42);
   });
@@ -416,7 +423,7 @@ describe("oneOf parse paths", () => {
 
   it("oneOf dispatches by index from [index, value] response", () => {
     const ds = new FakeDataSource({ generates: [[1, true]] });
-    const tc = new hegel.TestCase(ds, false);
+    const tc = new TestCase(ds, false);
     const result = tc.draw(gs.oneOf(gs.integers(), gs.booleans()));
     expect(result).toBe(true);
   });
@@ -424,11 +431,11 @@ describe("oneOf parse paths", () => {
   it("oneOf routes the value to the matching branch's parseRaw", () => {
     // Branches with different shapes: a string-typed branch and an integer-typed branch.
     const ds0 = new FakeDataSource({ generates: [[0, "abc"]] });
-    const tc0 = new hegel.TestCase(ds0, false);
+    const tc0 = new TestCase(ds0, false);
     expect(tc0.draw(gs.oneOf<string | number>(gs.text(), gs.integers()))).toBe("abc");
 
     const ds1 = new FakeDataSource({ generates: [[1, 42]] });
-    const tc1 = new hegel.TestCase(ds1, false);
+    const tc1 = new TestCase(ds1, false);
     expect(tc1.draw(gs.oneOf<string | number>(gs.text(), gs.integers()))).toBe(42);
   });
 
@@ -437,11 +444,11 @@ describe("oneOf parse paths", () => {
     const branch0 = gs.integers({ minValue: 0, maxValue: 9 }).map((x) => x * 10);
     const branch1 = gs.integers({ minValue: 0, maxValue: 9 }).map((x) => x + 100);
     const ds = new FakeDataSource({ generates: [[0, 7]] });
-    const tc0 = new hegel.TestCase(ds, false);
+    const tc0 = new TestCase(ds, false);
     expect(tc0.draw(gs.oneOf(branch0, branch1))).toBe(70);
 
     const ds2 = new FakeDataSource({ generates: [[1, 7]] });
-    const tc1 = new hegel.TestCase(ds2, false);
+    const tc1 = new TestCase(ds2, false);
     expect(tc1.draw(gs.oneOf(branch0, branch1))).toBe(107);
   });
 });
@@ -454,7 +461,7 @@ describe("binary parse paths", () => {
   it("parseBytes handles Buffer input", () => {
     const buf = Buffer.from([1, 2, 3]);
     const ds = new FakeDataSource({ generates: [buf] });
-    const tc = new hegel.TestCase(ds, false);
+    const tc = new TestCase(ds, false);
     const result = tc.draw(gs.binary());
     expect(result).toBeInstanceOf(Uint8Array);
     // Buffer extends Uint8Array, so instanceof check returns raw Buffer
@@ -464,7 +471,7 @@ describe("binary parse paths", () => {
   it("parseBytes handles Uint8Array input", () => {
     const arr = new Uint8Array([4, 5, 6]);
     const ds = new FakeDataSource({ generates: [arr] });
-    const tc = new hegel.TestCase(ds, false);
+    const tc = new TestCase(ds, false);
     const result = tc.draw(gs.binary());
     expect(result).toBe(arr);
   });
@@ -503,16 +510,16 @@ describe("Generator validation errors", () => {
 describe("FilteredGenerator with fake DataSource", () => {
   it("filter retries and returns when predicate passes", () => {
     const ds = new FakeDataSource({ generates: [1, 2, 10] });
-    const tc = new hegel.TestCase(ds, false);
+    const tc = new TestCase(ds, false);
     const gen = gs.integers().filter((x) => x >= 10);
     expect(tc.draw(gen)).toBe(10);
   });
 
-  it("filter throws hegel.AssumeError after 3 failures", () => {
+  it("filter throws AssumeError after 3 failures", () => {
     const ds = new FakeDataSource({ generates: [1, 2, 3] });
-    const tc = new hegel.TestCase(ds, false);
+    const tc = new TestCase(ds, false);
     const gen = gs.integers().filter((x) => x > 100);
-    expect(() => tc.draw(gen)).toThrow(hegel.AssumeError);
+    expect(() => tc.draw(gen)).toThrow(AssumeError);
   });
 });
 
@@ -524,7 +531,7 @@ describe("FlatMappedGenerator with fake DataSource", () => {
   it("flatMap draws from source then from derived generator", () => {
     // First generate returns the source value, second returns the derived value
     const ds = new FakeDataSource({ generates: [3, 42] });
-    const tc = new hegel.TestCase(ds, false);
+    const tc = new TestCase(ds, false);
     const gen = gs.integers().flatMap((_n) => gs.integers());
     expect(tc.draw(gen)).toBe(42);
   });
@@ -572,7 +579,7 @@ describe("Collection protocol via fake DataSource", () => {
       generates: [10, 20],
       collectionCounts: 2,
     });
-    const tc = new hegel.TestCase(ds, false);
+    const tc = new TestCase(ds, false);
     const gen = gs.arrays(
       gs.composite((inner) => inner.draw(gs.integers())),
       { maxSize: 5 },
@@ -586,7 +593,7 @@ describe("Collection protocol via fake DataSource", () => {
       generates: [10, 20],
       collectionCounts: 2,
     });
-    const tc = new hegel.TestCase(ds, false);
+    const tc = new TestCase(ds, false);
     const gen = gs.sets(
       gs.composite((inner) => inner.draw(gs.integers())),
       { maxSize: 5 },
@@ -600,7 +607,7 @@ describe("Collection protocol via fake DataSource", () => {
       generates: [1, 10, 2, 20],
       collectionCounts: 2,
     });
-    const tc = new hegel.TestCase(ds, false);
+    const tc = new TestCase(ds, false);
     const gen = gs.maps(
       gs.composite((inner) => inner.draw(gs.integers())),
       gs.composite((inner) => inner.draw(gs.integers())),
@@ -613,19 +620,6 @@ describe("Collection protocol via fake DataSource", () => {
         [2, 20],
       ]),
     );
-  });
-});
-
-// ---------------------------------------------------------------------------
-// drawSilent
-// ---------------------------------------------------------------------------
-
-describe("drawSilent", () => {
-  it("draws a value without recording output", () => {
-    const ds = new FakeDataSource({ generates: [42] });
-    const tc = new hegel.TestCase(ds, false);
-    const value = tc.drawSilent(gs.integers());
-    expect(value).toBe(42);
   });
 });
 

--- a/tests/exports.test.ts
+++ b/tests/exports.test.ts
@@ -1,0 +1,28 @@
+import { describe, test, expect } from "vitest";
+import * as hegel from "@hegeldev/hegel";
+import * as gs from "@hegeldev/hegel/generators";
+
+describe("public export shape", () => {
+  test("hegel.generators is the same namespace as @hegeldev/hegel/generators", () => {
+    // The root-namespace re-export and the subpath export must resolve to
+    // the same module so users can mix and match without surprise.
+    expect(hegel.generators).toBeDefined();
+    for (const key of Object.keys(gs)) {
+      expect(hegel.generators[key as keyof typeof hegel.generators]).toBe(
+        gs[key as keyof typeof gs],
+      );
+    }
+  });
+
+  test("a property test runs via hegel.generators.* without the subpath import", () =>
+    // This is the path the namespace re-export unlocks: users only need to
+    // import `@hegeldev/hegel` and can reach generators through `hegel.generators`.
+    hegel.test(
+      (tc) => {
+        const n = tc.draw(hegel.generators.integers({ minValue: 0, maxValue: 100 }));
+        expect(n).toBeGreaterThanOrEqual(0);
+        expect(n).toBeLessThanOrEqual(100);
+      },
+      { testCases: 20 },
+    ));
+});

--- a/tests/runner-coverage.test.ts
+++ b/tests/runner-coverage.test.ts
@@ -1,7 +1,7 @@
 /**
  * Tests targeting uncovered lines in runner.ts, specifically:
  * - Hegel.run() settings branches (database, suppressHealthCheck)
- * - hegel.ServerDataSource error handling paths
+ * - ServerDataSource error handling paths
  * - Health check failure detection
  * - Flaky test detection
  * - Server error (invalid schema) detection
@@ -10,13 +10,14 @@
 import { describe, test, expect } from "vitest";
 import * as hegel from "@hegeldev/hegel";
 import * as gs from "@hegeldev/hegel/generators";
+import { defaultSettings } from "../src/runner.js";
 
 describe("defaultSettings CI detection", () => {
   test("defaultSettings returns database='disabled' when CI env var is set", () => {
     const original = process.env["CI"];
     try {
       process.env["CI"] = "true";
-      const settings = hegel.defaultSettings();
+      const settings = defaultSettings();
       expect(settings.database).toEqual(hegel.Database.disabled);
       expect(settings.derandomize).toBe(true);
     } finally {
@@ -51,7 +52,7 @@ describe("defaultSettings CI detection", () => {
     try {
       // Set GITHUB_ACTIONS which expects value "true"
       process.env["GITHUB_ACTIONS"] = "true";
-      const settings = hegel.defaultSettings();
+      const settings = defaultSettings();
       expect(settings.database).toEqual(hegel.Database.disabled);
       expect(settings.derandomize).toBe(true);
     } finally {
@@ -89,7 +90,7 @@ describe("defaultSettings CI detection", () => {
       delete process.env[key];
     }
     try {
-      const settings = hegel.defaultSettings();
+      const settings = defaultSettings();
       expect(settings.database).toEqual(hegel.Database.unset);
       expect(settings.derandomize).toBe(false);
     } finally {
@@ -144,7 +145,7 @@ describe("settings branches", () => {
 describe("server error detection", () => {
   test("invalid schema triggers server error", () => {
     // Send a schema the server rejects (integer with min > max).
-    // This exercises the generic server error path in hegel.ServerDataSource.sendRequest.
+    // This exercises the generic server error path in ServerDataSource.sendRequest.
     const badGen = new gs.BasicGenerator({ type: "integer", min_value: 100, max_value: 0 });
     expect(() =>
       hegel.test(

--- a/tests/runner.test.ts
+++ b/tests/runner.test.ts
@@ -5,10 +5,11 @@
 import { describe, test, it, expect } from "vitest";
 import * as hegel from "@hegeldev/hegel";
 import * as gs from "@hegeldev/hegel/generators";
+import { AssumeError, Labels, StopTestError, TestCase } from "../src/testCase.js";
 
 describe("StopTestError", () => {
   it("has correct name and message", () => {
-    const e = new hegel.StopTestError();
+    const e = new StopTestError();
     expect(e.name).toBe("StopTestError");
     expect(e).toBeInstanceOf(Error);
     expect(e.message).toBe("Server ran out of data (StopTest)");
@@ -17,7 +18,7 @@ describe("StopTestError", () => {
 
 describe("AssumeError", () => {
   it("has correct name and message", () => {
-    const e = new hegel.AssumeError();
+    const e = new AssumeError();
     expect(e.name).toBe("AssumeError");
     expect(e).toBeInstanceOf(Error);
     expect(e.message).toBe("Assumption rejected");
@@ -25,26 +26,26 @@ describe("AssumeError", () => {
 });
 
 // ---------------------------------------------------------------------------
-// hegel.Labels constants
+// Labels constants
 // ---------------------------------------------------------------------------
 
 describe("Labels", () => {
   it("has correct values", () => {
-    expect(hegel.Labels.LIST).toBe(1);
-    expect(hegel.Labels.LIST_ELEMENT).toBe(2);
-    expect(hegel.Labels.SET).toBe(3);
-    expect(hegel.Labels.SET_ELEMENT).toBe(4);
-    expect(hegel.Labels.MAP).toBe(5);
-    expect(hegel.Labels.MAP_ENTRY).toBe(6);
-    expect(hegel.Labels.TUPLE).toBe(7);
-    expect(hegel.Labels.ONE_OF).toBe(8);
-    expect(hegel.Labels.OPTIONAL).toBe(9);
-    expect(hegel.Labels.FIXED_DICT).toBe(10);
-    expect(hegel.Labels.FLAT_MAP).toBe(11);
-    expect(hegel.Labels.FILTER).toBe(12);
-    expect(hegel.Labels.MAPPED).toBe(13);
-    expect(hegel.Labels.SAMPLED_FROM).toBe(14);
-    expect(hegel.Labels.ENUM_VARIANT).toBe(15);
+    expect(Labels.LIST).toBe(1);
+    expect(Labels.LIST_ELEMENT).toBe(2);
+    expect(Labels.SET).toBe(3);
+    expect(Labels.SET_ELEMENT).toBe(4);
+    expect(Labels.MAP).toBe(5);
+    expect(Labels.MAP_ENTRY).toBe(6);
+    expect(Labels.TUPLE).toBe(7);
+    expect(Labels.ONE_OF).toBe(8);
+    expect(Labels.OPTIONAL).toBe(9);
+    expect(Labels.FIXED_DICT).toBe(10);
+    expect(Labels.FLAT_MAP).toBe(11);
+    expect(Labels.FILTER).toBe(12);
+    expect(Labels.MAPPED).toBe(13);
+    expect(Labels.SAMPLED_FROM).toBe(14);
+    expect(Labels.ENUM_VARIANT).toBe(15);
   });
 });
 
@@ -167,7 +168,7 @@ describe("async test bodies", () => {
     expect(() =>
       hegel.test((async (tc) => {
         tc.draw(gs.booleans());
-      }) as (tc: hegel.TestCase) => void),
+      }) as (tc: TestCase) => void),
     ).toThrow(/hegel\.testAsync/);
   });
 

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,9 +1,9 @@
 {
   "$schema": "https://typedoc.org/schema.json",
-  "entryPoints": ["src/index.ts", "src/generators/index.ts"],
+  "entryPoints": ["src/index.ts"],
   "out": "docs",
   "treatWarningsAsErrors": true,
   "disableSources": true,
-  "readme": "README.md",
+  "readme": "none",
   "excludeInternal": true
 }


### PR DESCRIPTION
<details><summary>Claude-written description</summary>

This release adds a getting-started tutorial as the landing page of the API documentation (mirrors the shape of hegel-rust's `lib.rs` and hegel-go's package doc), makes `generators` reachable as a namespace from the root import (`hegel.generators.integers()` works alongside the existing `import * as gs from "@hegeldev/hegel/generators"`), and trims the public API of `@hegeldev/hegel` to the names a user-facing test actually uses: `test`, `testAsync`, `TestCase`, `Settings`, `Verbosity`, `HealthCheck`, `Database`, and the `generators` namespace.

Demoted exports (`Collection`, `Labels`, `StopTestError`, `AssumeError`, `ServerDataSource`, `defaultSettings`, `Connection`, `Stream`, `HegelSession`, `HEGEL_SERVER_VERSION`, and the `DataSource`, `GeneratorLike`, `TestCaseResult`, `TestLocation`, `Packet` types) remain available to internal code via the source modules. Tests that touched them now relative-import from `../src/*.js`, matching the pattern already used for `Connection`/`Stream`/`Packet`.

`TestCase.drawSilent` was removed, and `isLastRun`/`testAborted`/`startSpan`/`stopSpan` are marked `@internal`. The `GeneratorLike` interface was a workaround for a `testCase.ts` ↔ `generators/core.ts` import cycle; replaced with a type-only `import type { Generator }` that breaks the cycle without runtime cost.

Mechanics of the docs landing page: a single TypeDoc entry point + `"readme": "none"` is what makes the entry-point's `@packageDocumentation` render at `docs/index.html`. With multiple entry points TypeDoc generates a synthetic project-level page above them; with `readme: "README.md"` (the previous default) the README displaces the entry-point comment. Single entry + `readme: "none"` is the configuration that puts the tutorial on the landing page. The `generators` namespace re-export is what makes the single entry point viable — without it, generator symbols would be unreachable from `src/index.ts` and would vanish from the docs.

A new `tests/exports.test.ts` asserts `hegel.generators.X === gs.X` for every export, proving the namespace re-export points at the same module rather than a duplicate.

Caveats:

- `RELEASE.md` is `patch`. The convention in `RELEASE-sample.md` reads "minor" for visible-API changes and "major" for breaking changes; this PR does both. Keeping `patch` is intentional per maintainer review — flagging it for the human reviewer's awareness.

</details>
