### PR TITLE
Bump pinned hegel-core to 0.9.1

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This patch bumps our pinned hegel-core from [0.6.0](https://github.com/hegeldev/hegel-core/releases/tag/v0.6.0) to [0.9.1](https://github.com/hegeldev/hegel-core/releases/tag/v0.9.1).

--- a/src/session.ts
+++ b/src/session.ts
@@ -13,9 +13,9 @@ import { Connection, Stream } from "./connection.js";
 import { HANDSHAKE_STRING } from "./protocol.js";
 import { findUv } from "./uv.js";
 
-export const HEGEL_SERVER_VERSION = "0.6.0";
-const SUPPORTED_PROTOCOL_MIN = "0.12";
-const SUPPORTED_PROTOCOL_MAX = "0.12";
+export const HEGEL_SERVER_VERSION = "0.9.1";
+const SUPPORTED_PROTOCOL_MIN = "0.15";
+const SUPPORTED_PROTOCOL_MAX = "0.15";
 const HEGEL_SERVER_COMMAND_ENV = "HEGEL_SERVER_COMMAND";
 const HEGEL_SERVER_DIR = ".hegel";
 


### PR DESCRIPTION
Duplicate of #34 to get a fresh CI run after the GitHub Actions outage. Local `just check` passes (383 tests, 100% coverage).

<details>

PR #34's CI queue has been stuck since the outage; this PR is a clean trigger to verify the bump works. If CI passes here, the equivalent commit on `ci/bump-hegel-core` will pass too and #34 can be merged.

</details>