### PR TITLE
Detect flaky strategy hang

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Fix a hang when a property test uses inconsistent data generation (for example, conditional `tc.draw()` calls on external state). The client now reports the server's flaky-strategy error instead of blocking forever. See https://github.com/hegeldev/hegel-typescript/issues/48.

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -7,7 +7,13 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { HegelSession } from "./session.js";
-import { TestCase, StopTestError, AssumeError, type DataSource } from "./testCase.js";
+import {
+  TestCase,
+  StopTestError,
+  FlakyAbortError,
+  AssumeError,
+  type DataSource,
+} from "./testCase.js";
 import { encode, decode } from "cbor-x";
 import type { Connection, Stream } from "./connection.js";
 
@@ -122,11 +128,11 @@ export class ServerDataSource implements DataSource {
         this._aborted = true;
         throw new StopTestError();
       }
-      /* v8 ignore start: FlakyStrategyDefinition is detected in test_done results, not here */
+      /* v8 ignore start: flaky during generate is rare; test_done path covered by integration tests */
       if (errorMsg.includes("FlakyStrategyDefinition") || errorMsg.includes("FlakyReplay")) {
         this.stream.markClosed();
         this._aborted = true;
-        throw new StopTestError();
+        throw new FlakyAbortError();
       }
       /* v8 ignore stop */
       /* v8 ignore start: requires server to crash mid-request */
@@ -180,17 +186,26 @@ export class ServerDataSource implements DataSource {
 
   markComplete(status: string, origin: string | null): void {
     try {
-      const message: Record<string, unknown> = {
+      // Send mark_complete without waiting for the reply. We never used the
+      // reply payload (the old code called receiveReply and discarded it), and
+      // the protocol does not require the client to block here before reading
+      // test_done on the main test stream. Blocking does deadlock when the
+      // server reports flaky in test_done before answering this request
+      // (issue #48). hegel-go can wait in doRequest because a background read
+      // loop keeps draining the pipe; our synchronous reader cannot. The stream
+      // is closed unconditionally in finalizeTestCase afterward.
+      const encoded = encode({
         command: "mark_complete",
         status,
         origin: origin ?? null,
-      };
-      const encoded = encode(message);
-      const id = this.stream.sendRequest(encoded);
-      this.stream.receiveReply(id);
+      });
+      this.stream.sendRequest(encoded);
     } catch {
       // ignore errors during mark_complete
     }
+  }
+
+  closeTestCase(): void {
     this.stream.close();
   }
 
@@ -224,6 +239,7 @@ function classifyResult(
 ): { result: TestCaseResult; origin: string | null } {
   if (e instanceof AssumeError) return { result: { status: "invalid" }, origin: null };
   if (e instanceof StopTestError) return { result: { status: "invalid" }, origin: null };
+  if (e instanceof FlakyAbortError) return { result: { status: "invalid" }, origin: null };
 
   if (isFinal) {
     const msg = e instanceof Error ? e.message : String(e);
@@ -241,10 +257,19 @@ function finalizeTestCase(
   result: TestCaseResult,
   origin: string | null,
 ): void {
-  if (tc.testAborted) return;
-  const status =
-    result.status === "valid" ? "VALID" : result.status === "invalid" ? "INVALID" : "INTERESTING";
-  dataSource.markComplete(status, origin);
+  try {
+    if (!tc.testAborted) {
+      const status =
+        result.status === "valid"
+          ? "VALID"
+          : result.status === "invalid"
+            ? "INVALID"
+            : "INTERESTING";
+      dataSource.markComplete(status, origin);
+    }
+  } finally {
+    dataSource.closeTestCase();
+  }
 }
 
 export async function runTestCaseAsync(

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -469,16 +469,21 @@ export class Hegel {
       }
     }
 
-    // Check for server-side errors
+    // Check for server-side errors. Close the test stream before throwing so
+    // the server is not left waiting for acks on a follow-up test_case (which
+    // would wedge the shared session for the next hegel.test() call).
     /* v8 ignore start: requires server to report error in test_done results */
     if (resultData["error"]) {
+      testStream.close();
       throw new Error(`Server error: ${resultData["error"]}`);
     }
     /* v8 ignore stop */
     if (resultData["health_check_failure"]) {
+      testStream.close();
       throw new Error(`Health check failure:\n${resultData["health_check_failure"]}`);
     }
     if (resultData["flaky"]) {
+      testStream.close();
       throw new Error(`Flaky test detected: ${resultData["flaky"]}`);
     }
 

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -192,8 +192,7 @@ export class ServerDataSource implements DataSource {
       // test_done on the main test stream. Blocking does deadlock when the
       // server reports flaky in test_done before answering this request
       // (issue #48). hegel-go can wait in doRequest because a background read
-      // loop keeps draining the pipe; our synchronous reader cannot. The stream
-      // is closed unconditionally in finalizeTestCase afterward.
+      // loop keeps draining the pipe; our synchronous reader cannot.
       const encoded = encode({
         command: "mark_complete",
         status,
@@ -203,9 +202,6 @@ export class ServerDataSource implements DataSource {
     } catch {
       // ignore errors during mark_complete
     }
-  }
-
-  closeTestCase(): void {
     this.stream.close();
   }
 
@@ -257,19 +253,10 @@ function finalizeTestCase(
   result: TestCaseResult,
   origin: string | null,
 ): void {
-  try {
-    if (!tc.testAborted) {
-      const status =
-        result.status === "valid"
-          ? "VALID"
-          : result.status === "invalid"
-            ? "INVALID"
-            : "INTERESTING";
-      dataSource.markComplete(status, origin);
-    }
-  } finally {
-    dataSource.closeTestCase();
-  }
+  if (tc.testAborted) return;
+  const status =
+    result.status === "valid" ? "VALID" : result.status === "invalid" ? "INVALID" : "INTERESTING";
+  dataSource.markComplete(status, origin);
 }
 
 export async function runTestCaseAsync(

--- a/src/testCase.ts
+++ b/src/testCase.ts
@@ -70,7 +70,6 @@ export interface DataSource {
   collectionMore(collectionId: number): boolean;
   collectionReject(collectionId: number, why?: string): void;
   markComplete(status: string, origin: string | null): void;
-  closeTestCase(): void;
   testAborted(): boolean;
 }
 

--- a/src/testCase.ts
+++ b/src/testCase.ts
@@ -18,6 +18,14 @@ export class StopTestError extends Error {
   }
 }
 
+/** Raised when the server detects non-deterministic data generation. */
+export class FlakyAbortError extends Error {
+  constructor() {
+    super("Flaky test detected");
+    this.name = "FlakyAbortError";
+  }
+}
+
 export class AssumeError extends Error {
   constructor() {
     super("Assumption rejected");
@@ -62,6 +70,7 @@ export interface DataSource {
   collectionMore(collectionId: number): boolean;
   collectionReject(collectionId: number, why?: string): void;
   markComplete(status: string, origin: string | null): void;
+  closeTestCase(): void;
   testAborted(): boolean;
 }
 

--- a/tests/datasource.test.ts
+++ b/tests/datasource.test.ts
@@ -89,10 +89,6 @@ class FakeDataSource implements DataSource {
     this._markCompleteCalls.push({ status, origin });
   }
 
-  closeTestCase(): void {
-    // no-op
-  }
-
   testAborted(): boolean {
     return this._aborted;
   }

--- a/tests/datasource.test.ts
+++ b/tests/datasource.test.ts
@@ -350,9 +350,13 @@ describe("text and characters with alphabet", () => {
 describe("runTestCase with FlakyAbortError", () => {
   it("classifyResult treats FlakyAbortError as invalid", () => {
     const ds = new FakeDataSource();
-    const result = runTestCase(ds, () => {
-      throw new FlakyAbortError();
-    }, false);
+    const result = runTestCase(
+      ds,
+      () => {
+        throw new FlakyAbortError();
+      },
+      false,
+    );
     expect(result.status).toBe("invalid");
   });
 });

--- a/tests/datasource.test.ts
+++ b/tests/datasource.test.ts
@@ -9,6 +9,7 @@ import * as gs from "@hegeldev/hegel/generators";
 import {
   AssumeError,
   Collection,
+  FlakyAbortError,
   Labels,
   StopTestError,
   TestCase,
@@ -86,6 +87,10 @@ class FakeDataSource implements DataSource {
 
   markComplete(status: string, origin: string | null): void {
     this._markCompleteCalls.push({ status, origin });
+  }
+
+  closeTestCase(): void {
+    // no-op
   }
 
   testAborted(): boolean {
@@ -171,6 +176,10 @@ describe("TestCase with fake DataSource", () => {
     const ds = new FakeDataSource();
     const tc = new TestCase(ds, false);
     expect(() => tc.assume(true)).not.toThrow();
+  });
+
+  it("FlakyAbortError carries the flaky sentinel message", () => {
+    expect(new FlakyAbortError().message).toBe("Flaky test detected");
   });
 });
 
@@ -337,6 +346,16 @@ describe("text and characters with alphabet", () => {
 // arbitrary thrown values. Direct calls with a fake DataSource are the only
 // way to cover the `String(e)` and `!(e instanceof Error)` branches.
 // ---------------------------------------------------------------------------
+
+describe("runTestCase with FlakyAbortError", () => {
+  it("classifyResult treats FlakyAbortError as invalid", () => {
+    const ds = new FakeDataSource();
+    const result = runTestCase(ds, () => {
+      throw new FlakyAbortError();
+    }, false);
+    expect(result.status).toBe("invalid");
+  });
+});
 
 describe("runTestCase with non-Error throws", () => {
   it("extractOrigin returns '<unknown>' when a non-Error is thrown", () => {

--- a/tests/runner-coverage.test.ts
+++ b/tests/runner-coverage.test.ts
@@ -202,7 +202,7 @@ describe("server error detection", () => {
           tc.draw(gs.booleans());
           calls++;
         },
-        { testCases: 2 },
+        { testCases: 2, database: hegel.Database.disabled },
       ),
     ).toThrow("Flaky test detected");
   });

--- a/tests/runner-coverage.test.ts
+++ b/tests/runner-coverage.test.ts
@@ -165,13 +165,15 @@ describe("server error detection", () => {
           const x = tc.draw(gs.integers({ minValue: 0, maxValue: 1000 }));
           tc.assume(x === 500);
         },
-        { testCases: 100 },
+        { testCases: 100, database: hegel.Database.disabled },
       ),
     ).toThrow("Health check failure");
   });
 
   test("flaky test detected", () => {
     // A test that fails on the first run but passes on replay is flaky.
+    // Disable the example database so prior tests in this file (which share
+    // the Hegel session) do not leave stale entries that mask flaky replay.
     let seen = false;
     expect(() =>
       hegel.test(
@@ -182,7 +184,25 @@ describe("server error detection", () => {
             throw new Error("flaky failure");
           }
         },
-        { testCases: 100 },
+        { testCases: 100, database: hegel.Database.disabled },
+      ),
+    ).toThrow("Flaky test detected");
+  });
+
+  test("flaky strategy definition from external state", () => {
+    // Conditional draws on external state make generation inconsistent across
+    // test cases. The server reports this as a flaky strategy definition.
+    let calls = 0;
+    expect(() =>
+      hegel.test(
+        (tc) => {
+          if (calls % 2 === 0) {
+            tc.draw(gs.integers());
+          }
+          tc.draw(gs.booleans());
+          calls++;
+        },
+        { testCases: 2 },
       ),
     ).toThrow("Flaky test detected");
   });


### PR DESCRIPTION
Fixes #48: property tests with inconsistent data generation (e.g. conditional tc.draw() on external state) hung because the client blocked on the mark_complete reply while the server had already moved on to report flaky in test_done. We now send mark_complete without waiting—the reply was never used, and hegel-go can afford to wait only because it has a background read loop. We also close the main test stream before throwing on flaky (and other test_done errors), which fixes a pre-existing 30s wedge in the shared Hegel session when flaky tests run back-to-back in the suite. Adds a repro test and FlakyAbortError for flaky-during-generate, matching Go’s flakyAbort.