### PR TITLE
Fix optional(just(null)) wire schema branch collapse

### DIFF
--- a/src/generators/combinators.ts
+++ b/src/generators/combinators.ts
@@ -7,6 +7,19 @@
 import { TestCase, Labels, generateRaw } from "../testCase.js";
 import { Generator, BasicGenerator } from "./core.js";
 
+/** Wire value for `just(null)` — distinct from optional's absent `{ value: null }`. */
+const JUST_NULL_WIRE = false;
+
+/** Wire value for `just(undefined)` — distinct from optional absent and `just(null)`. */
+const JUST_UNDEFINED_WIRE = true;
+
+function constantWireValue(value: unknown): unknown {
+  if (value === null) return JUST_NULL_WIRE;
+  if (value === undefined) return JUST_UNDEFINED_WIRE;
+  if (typeof value === "object") return null;
+  return value;
+}
+
 class JustGenerator<T> extends Generator<T> {
   constructor(private readonly value: T) {
     super();
@@ -18,7 +31,7 @@ class JustGenerator<T> extends Generator<T> {
 
   override asBasic(): BasicGenerator<T> {
     const value = this.value;
-    return new BasicGenerator({ type: "constant", value: null }, () => value);
+    return new BasicGenerator({ type: "constant", value: constantWireValue(value) }, () => value);
   }
 }
 

--- a/tests/optional-just-null.test.ts
+++ b/tests/optional-just-null.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Regression tests for optional(just(null)): absent-null and present-null must
+ * use distinct wire schemas so Hegel can choose between the branches.
+ */
+
+import { describe, it, expect } from "vitest";
+import * as gs from "@hegeldev/hegel/generators";
+import { TestCase, type DataSource } from "../src/testCase.js";
+
+class FakeDataSource implements DataSource {
+  constructor(private readonly generates: unknown[]) {}
+
+  private index = 0;
+
+  generate(_schema: Record<string, unknown>): unknown {
+    return this.generates[this.index++];
+  }
+
+  startSpan(_label: number): void {}
+  stopSpan(_discard: boolean): void {}
+  newCollection(_minSize: number, _maxSize?: number): number {
+    return 1;
+  }
+  collectionMore(_collectionId: number): boolean {
+    return false;
+  }
+  collectionReject(_collectionId: number, _why?: string): void {}
+  markComplete(_status: string, _origin: string | null): void {}
+  testAborted(): boolean {
+    return false;
+  }
+}
+
+describe("optional(just(null))", () => {
+  it("does not send duplicate constant-null branches on the wire", () => {
+    const basic = gs.optional(gs.just(null)).asBasic();
+    expect(basic).not.toBeNull();
+
+    const generators = (basic!.schema as { generators: Record<string, unknown>[] }).generators;
+    expect(generators).toHaveLength(2);
+    expect(generators[0]).not.toEqual(generators[1]);
+  });
+
+  it("dispatches absent on index 0 and present-null on index 1", () => {
+    const absent = new TestCase(new FakeDataSource([[0, null]]), false);
+    const present = new TestCase(new FakeDataSource([[1, false]]), false);
+
+    expect(absent.draw(gs.optional(gs.just(null)))).toBeNull();
+    expect(present.draw(gs.optional(gs.just(null)))).toBeNull();
+    expect(gs.just(null).asBasic()!.schema).toEqual({ type: "constant", value: false });
+  });
+});


### PR DESCRIPTION
Fixes wire-level branch collapse in optional(just(null))
just(null) / just(undefined) use distinct wire sentinels; primitives encode their real values
Adds tests/optional-just-null.test.ts
Note: absent and present-null still both parse to JavaScript null — this fixes protocol/shrinking, not Option<null> at the value level.

main` still fails `runner-coverage.test.ts > flaky test detected`, so the full suite won't go green until the flaky hang fix lands. I'll rebase once that's merged.