### PR TITLE
claude: default fromRegex to fullmatch

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,3 @@
-RELEASE_TYPE: major
+RELEASE_TYPE: minor
 
 This release changes the default value of `fullmatch` in `fromRegex` from `false` to `true`.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,13 @@
+RELEASE_TYPE: minor
+
+This release changes the default match mode of `fromRegex` from "contains a
+match" to "fullmatch": generated strings must now match the pattern in their
+entirety, rather than merely containing a match somewhere.
+
+```ts
+gs.fromRegex("[0-9]{3}");
+// before: any string containing three digits, e.g. "ab123cd"
+// now:    exactly three digits, e.g. "123"
+
+gs.fromRegex("[0-9]{3}", { fullmatch: false }); // previous behavior
+```

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,13 +1,3 @@
-RELEASE_TYPE: minor
+RELEASE_TYPE: major
 
-This release changes the default match mode of `fromRegex` from "contains a
-match" to "fullmatch": generated strings must now match the pattern in their
-entirety, rather than merely containing a match somewhere.
-
-```ts
-gs.fromRegex("[0-9]{3}");
-// before: any string containing three digits, e.g. "ab123cd"
-// now:    exactly three digits, e.g. "123"
-
-gs.fromRegex("[0-9]{3}", { fullmatch: false }); // previous behavior
-```
+This release changes the default value of `fullmatch` in `fromRegex` from `false` to `true`.

--- a/src/generators/strings.ts
+++ b/src/generators/strings.ts
@@ -187,6 +187,7 @@ export function binary(options?: BinaryOptions): Generator<Uint8Array> {
 }
 
 export interface RegexOptions {
+  /** Whether the entire string must match the pattern (default `true`). */
   fullmatch?: boolean;
 }
 
@@ -195,12 +196,16 @@ class FromRegexGenerator extends SchemaStringGenerator {
     super({
       type: "regex",
       pattern,
-      fullmatch: options?.fullmatch ?? false,
+      fullmatch: options?.fullmatch ?? true,
     });
   }
 }
 
-/** Generate strings matching a regex pattern. Defaults to substring match. */
+/**
+ * Generate strings matching a regex pattern. Defaults to full match (the
+ * entire string matches the pattern); pass `{ fullmatch: false }` for
+ * substring/contains behavior.
+ */
 export function fromRegex(pattern: string, options?: RegexOptions): Generator<string> {
   return new FromRegexGenerator(pattern, options);
 }

--- a/tests/from-regex.test.ts
+++ b/tests/from-regex.test.ts
@@ -7,7 +7,16 @@ describe("gs.fromRegex()", () => {
     expect(gs.fromRegex("[0-9]+").asBasic()).not.toBeNull();
   });
 
-  test("generates strings matching the pattern", () =>
+  test("generates full matches by default", () =>
+    hegel.test(
+      (tc) => {
+        const v = tc.draw(gs.fromRegex("[0-9]{3}"));
+        expect(v).toMatch(/^[0-9]{3}$/);
+      },
+      { testCases: 50 },
+    ));
+
+  test("fullmatch=true generates full matches", () =>
     hegel.test(
       (tc) => {
         const v = tc.draw(gs.fromRegex("[0-9]{3}", { fullmatch: true }));


### PR DESCRIPTION
<details><summary>Claude-written description</summary>

Flips the default match mode of `fromRegex` from "contains a match" to "fullmatch": generated strings must now match the pattern in their entirety. Pass `{ fullmatch: false }` for the previous substring/contains behavior.

This library always sends `fullmatch` explicitly in the schema it submits, so the change is self-contained — no server/protocol change is involved.

Changes:
- `FromRegexGenerator` now defaults `fullmatch` to `true`; doc comments on `fromRegex` and `RegexOptions.fullmatch` updated to match.
- Tests cover the new default (only full matches), explicit `{ fullmatch: true }`, and `{ fullmatch: false }` restoring contains behavior.
- `RELEASE.md` added with `RELEASE_TYPE: minor` (zerover: breaking changes are a minor bump pre-1.0).

Refs: hegeldev/hegel-rust#258

</details>
