### PR TITLE
Allow hegel-release bot to trigger the bump workflow's alignment step

### DIFF
--- a/.github/workflows/bump-hegel-rust.yml
+++ b/.github/workflows/bump-hegel-rust.yml
@@ -64,6 +64,10 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ steps.app-token.outputs.token }}
+          # hegel-rust fires this workflow via repository_dispatch using the
+          # hegel-release[bot] app token, so the actor is a bot. The action
+          # blocks bot-initiated runs by default; allow this specific bot.
+          allowed_bots: hegel-release
           prompt: |
             The pinned libhegel version was just bumped to v${{ steps.bump.outputs.version }}
             (src/libhegel-version.ts) on this checkout. Align the TypeScript koffi FFI wrapper in


### PR DESCRIPTION
The `Bump hegel-rust` workflow is fired by `repository_dispatch` from hegel-rust's release workflow, authenticated as `hegel-release[bot]`. `claude-code-action` blocks bot-initiated runs by default, so the FFI-alignment step has failed on all 19 runs since the workflow was added (Jun 29). hegel-go's copy of this workflow already carries the same one-line fix.

Note: this repo also has no `ANTHROPIC_API_KEY` secret (hegel-go does), so the step is expected to keep failing — differently — until a token is provisioned. Merging this anyway to clear the first failure and observe the second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)