### PR TITLE
Harden supersede author check against unlinked-email commits

### DIFF
--- a/.github/workflows/bump-hegel-rust.yml
+++ b/.github/workflows/bump-hegel-rust.yml
@@ -153,9 +153,14 @@ jobs:
             esac
             # Authors other than the bot on the PR's commits? (GraphQL reports
             # the bot's login without the [bot] suffix; check both spellings.)
+            # A commit whose author email isn't linked to a GitHub account
+            # reports login as an EMPTY STRING (not null), which jq's `//`
+            # treats as truthy — so test for "" explicitly to fall through to
+            # the git author name, and count a fully unknown author as human:
+            # never close a PR on an identity we couldn't resolve.
             others=$(gh pr view "$pr" --json commits \
-              --jq '[.commits[].authors[] | (.login // .name // empty)] | unique
-                    | map(select(. != "" and . != "hegel-release" and . != "hegel-release[bot]"))
+              --jq '[.commits[].authors[] | (if (.login // "") != "" then .login elif (.name // "") != "" then .name else "unknown author" end)] | unique
+                    | map(select(. != "hegel-release" and . != "hegel-release[bot]"))
                     | join(", ")')
             if [ -z "$others" ]; then
               gh pr close "$pr" --comment "Superseded by #${new_pr}, which pins libhegel ${VERSION}."


### PR DESCRIPTION
<details>
Porting #63's supersede step to hegel-go surfaced a flaw in its author-detection jq: on real GitHub data, a commit whose author email is **not linked to a GitHub account** reports `login` as an *empty string*, not `null` — and jq's `//` operator treats `""` as truthy. So `.login // .name` yielded `""`, the git-author-name fallback never fired, and (with the empty string filtered out as noise) a human commit with an unlinked email would be misclassified as bot-only — closing a PR that carries someone's work, exactly what the check exists to prevent.

The extraction now tests for the empty string explicitly: an empty `login` falls through to the git author `name`, and a fully unknown author counts as `"unknown author"` — i.e. human, so the step never closes a PR on an identity it couldn't resolve. Fail-safe direction: uncertainty always means leave-open-with-comment, never close.

Dry-tested read-only against PR #62 (mixed human/agent commits): reports `DRMacIver, claude` → leave open. The same jq is being adopted verbatim across hegel-go/cpp/ocaml for consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
</details>
