### PR TITLE
Port new libhegel features automatically on version bumps

### DIFF
--- a/.claude/skills/align-libhegel/SKILL.md
+++ b/.claude/skills/align-libhegel/SKILL.md
@@ -13,6 +13,12 @@ symbols, and the binding layer must be re-aligned. The public
 `@hegeldev/hegel` API (`test`, `testAsync`, `Settings`, the generators) must
 **not** change as a result — only the internal layers.
 
+New capability the front end does not expose yet — a generator, setting, or
+protocol the release added — is deliberately out of scope here, and is the job
+of `.claude/skills/port-libhegel-features/SKILL.md`. This skill keeps the
+binding compiling with the public API fixed; that one grows the public API and
+records what it skipped in `LIBHEGEL-PARITY.md`.
+
 The layers, and what an ABI change usually touches:
 
 - **`src/libhegel.ts`** — the whole koffi surface. Three things move together
@@ -147,8 +153,9 @@ this client uses, three places move together: the **prototype string** (or
 - **Renamed/retyped symbol** → update all three together, plus any caller that
   consumed the old shape.
 - **New symbol** → bind it **only if the front end needs it** (see §5 — the
-  coverage gate forbids dead bindings). If nothing calls it, note it in the
-  commit message and move on.
+  coverage gate forbids dead bindings). If nothing calls it, it is new
+  capability, not an alignment: note it in the commit message and leave it to
+  `port-libhegel-features`.
 - **Changed signature** (a new arg, or a value moving from return to
   out-param) → remember the convention: ctx first, result-code return,
   produced value through a trailing out-param. A new _optional_ arg with a

--- a/.claude/skills/port-libhegel-features/SKILL.md
+++ b/.claude/skills/port-libhegel-features/SKILL.md
@@ -1,0 +1,279 @@
+---
+name: port-libhegel-features
+description: "How to expose new libhegel (hegel-c) capability in the public @hegeldev/hegel API after the pinned version moves. Use when the pin in src/libhegel-version.ts has advanced and you need to know what the engine gained and what to build on top of it, when asked to port a libhegel feature (a new generator, setting, result code, or protocol), when reviewing LIBHEGEL-PARITY.md, or when the port-libhegel-features workflow asks for a first stab at a version range."
+---
+
+# Porting new libhegel capability into the TypeScript API
+
+`align-libhegel` keeps the binding **compiling** across an ABI change and is
+deliberately API-preserving: it binds only what the front end already uses. So
+capability the engine gains is never picked up by it. This skill is the
+complement — given that libhegel moved from version A to version B, it answers
+_what new capability is there, and how does it become public
+`@hegeldev/hegel` API?_
+
+Read `.claude/skills/align-libhegel/SKILL.md` first if you have not: the ABI
+conventions (context-first, result-code return, trailing out-parameter,
+caller-owned handles), the koffi specifics, and the layer map all apply
+unchanged here and are assumed below.
+
+The output of a port is **not** "every new symbol is bound". It is: the
+mechanical features are implemented, tested and documented; the design-heavy
+ones are written up in the ledger; and `LIBHEGEL-PARITY.md` says which is
+which. A skipped feature that is not in the ledger is a feature nobody will
+ever remember to revisit.
+
+## 1. Determine what is new
+
+Two sources, both from hegel-rust at the release tags. The tag is
+`v<VERSION>` — the `v` prefix matters, the raw path without it 404s. The repo
+is public, so no token is needed.
+
+```bash
+OLD=0.32.5   # the ledger's last_ported, or the range you were given
+NEW=0.34.0   # the pin in src/libhegel-version.ts
+
+for v in "$OLD" "$NEW"; do
+  curl -sSL -o "/tmp/hegel-$v.h" \
+    "https://raw.githubusercontent.com/hegeldev/hegel-rust/v$v/hegel-c/include/hegel.h"
+done
+diff -u "/tmp/hegel-$OLD.h" "/tmp/hegel-$NEW.h"
+```
+
+The raw diff is noisy (doc comments move). Get the symbol delta first, then
+read the diff around each hit:
+
+```bash
+for v in "$OLD" "$NEW"; do
+  grep -oE '\bhegel_[a-z0-9_]+\s*\(' "/tmp/hegel-$v.h" | tr -d ' (' | sort -u > "/tmp/syms-$v"
+done
+comm -13 "/tmp/syms-$OLD" "/tmp/syms-$NEW"   # added
+comm -23 "/tmp/syms-$OLD" "/tmp/syms-$NEW"   # removed
+```
+
+Functions are not the whole delta. Also diff the non-function declarations —
+these carry protocol changes that no new symbol announces:
+
+```bash
+diff <(grep -E '^\s*(HEGEL_|#define)' "/tmp/hegel-$OLD.h") \
+     <(grep -E '^\s*(HEGEL_|#define)' "/tmp/hegel-$NEW.h")   # enum values, sentinels
+diff <(grep -E '^typedef|_t;' "/tmp/hegel-$OLD.h") \
+     <(grep -E '^typedef|_t;' "/tmp/hegel-$NEW.h")           # handles, structs
+```
+
+A sentinel whose _value_ changed (`HEGEL_STATE_MACHINE_DONE` went from `-1` to
+`INT64_MIN` in 0.33.0) and a function whose _signature_ grew a parameter are
+both invisible to the symbol delta and both break callers.
+
+Then read the changelog:
+
+```bash
+curl -sSL "https://raw.githubusercontent.com/hegeldev/hegel-rust/v$NEW/hegel-c/CHANGELOG.md"
+```
+
+Read every entry between `## $OLD` and `## $NEW`, not just the top one. The
+changelog is written for exactly this audience: it explains what a feature is
+_for_, the call order a frontend is expected to use, which parts are the
+frontend's choice, and what happens to frontends that ignore it. It is the
+difference between binding a symbol and porting a feature. Header signatures
+alone will not tell you that `hegel_recursion_finish` may report
+`HEGEL_E_RETRY` and that the client is expected to drop the value and
+regenerate from the root at most twice.
+
+## 2. Classify every new capability
+
+Group the delta into _features_, not symbols — twenty-one `hegel_printer_*`
+entry points are one feature. Then put each feature in exactly one bucket.
+
+**Mechanical — port it.** An additive generator, setting, result code, enum
+value, or span label whose shape in TypeScript is obvious because the library
+already has three of the same thing. The test is: can you name the existing
+export it will look like, and the options-object fields, without inventing
+anything? A new `hegel_generate_*` primitive is mechanical (`integers`,
+`floats`, `dates` are all the same shape). A new
+`hegel_settings_set_<name>(s, value)` is mechanical (it becomes a `Settings`
+field with a default, wired in `runner.ts`). A new `hegel_result_t` code or
+`hegel_run_status_t` value is mechanical when something in this client can
+actually provoke it.
+
+**Design-heavy — write it up, do not guess.** The feature needs a genuine
+public-API decision in TypeScript: a new user-facing concept, a callback
+protocol, a threading story, or a choice between several defensible shapes.
+Symptoms: you cannot write the signature without picking between two designs;
+the engine feature has no analogue anywhere in the current API; adopting it
+would change what an existing public method _does_; it needs worker threads,
+async, or a rendering model. **A bad guess at a printer API is worse than no
+printer API** — it ships public surface the library then has to keep or break,
+and it forecloses the design the owner would have chosen. Write the ledger
+entry and stop.
+
+**Not applicable — record and move on.** Engine-internal (shrinker,
+distribution, database changes with no ABI surface), already covered by
+existing API, or predicated on a feature this library does not have. The last
+one matters: a change to the stateful protocol is not applicable to a library
+with no stateful testing, but it is _not_ nothing — it belongs in the ledger
+as part of the "stateful testing" gap so nobody re-derives it next time.
+
+A feature can be split. If a family has one mechanical piece (an enum value)
+and a design-heavy core (the protocol that produces it), porting the piece on
+its own is usually dead code that fails the coverage gate — see §4. Prefer to
+keep the family together in one ledger entry and say so.
+
+## 3. What porting a generator actually involves
+
+Traced from `arrays` / `sets` (`src/generators/collections.ts`) and the
+integer path. Every one of these moves for a new engine-backed generator, in
+this order:
+
+1. **koffi prototype** — `bindLibrary` in `src/libhegel.ts`. A prototype
+   string (`f("int hegel_generate_x(void* ctx, void* tc, ...)")`) unless the
+   call passes a struct by value, which needs the `fs(name, [types])` helper
+   with anonymous `koffi.struct` `TypeObject`s.
+2. **`Bindings` field** — the typed wrapper surface in `src/libhegel.ts`. Any
+   parameter the wrapper hardcodes rather than exposing must be documented
+   here as a deliberate absorption.
+3. **`Libhegel` method** — the ergonomic wrapper, also in `src/libhegel.ts`.
+   It allocates the out-parameter array, funnels the result code through
+   `this.check(ctx, code, "hegel_generate_x")`, normalizes the out value
+   (`Number(...)` / `BigInt(...)` for 64-bit), and — if the call returns an
+   engine-owned buffer — copies it with `Libhegel.copyNativeBuffer` and frees
+   it in a `finally`.
+4. **Schema IR + interpreter** — `src/generate.ts`. Add a `case "<type>"` to
+   the `switch` in `generateValue`, and to `buildStringGenerator` instead if
+   the draw goes through a `hegel_string_generator_t`. Compound draws follow
+   `drawList` / `drawDict`: `lib.startSpan(ctx, tc, Labels.X)`, the draws,
+   `lib.stopSpan(ctx, tc, false)`, with every handle freed in a `finally`.
+   New span labels go in `Labels` in `src/testCase.ts` and **must mirror the
+   `HEGEL_LABEL_*` values in the header** — the current entries are an exact
+   subset of upstream 1–15, not client-invented numbers.
+5. **Public generator** — a `class XGenerator<T> extends Generator<T>` plus a
+   lowercase factory function in the right `src/generators/*.ts` file
+   (`numeric.ts`, `strings.ts`, `collections.ts`, `combinators.ts`,
+   `tuples.ts`, `compose.ts`). Options come in as a single optional
+   options-object interface (`XOptions`), defaults applied with `??`, invalid
+   combinations thrown as plain `Error` in the constructor. If the generator
+   is expressible as one schema, build a `BasicGenerator` in the constructor
+   and return it from `asBasic()` — that is what lets parent generators
+   compose a single schema instead of falling back to span-based draws.
+   Export the function and its options type from `src/generators/index.ts`.
+6. **Docs** — typedoc runs over `src/index.ts` only, with
+   `treatWarningsAsErrors: true` and `excludeInternal: true`. Every new public
+   export needs TSDoc, and a broken `{@link}` **fails `just check-docs`**. If
+   the feature is something a new user would look for, add it to the
+   `@packageDocumentation` guide at the top of `src/index.ts`.
+7. **Changelog** — a root `RELEASE.md`. Required by
+   `.github/scripts/release.py check` for any PR touching `src/`, so a port PR
+   always needs one. Follow `.claude/skills/changelog/SKILL.md`: an additive
+   feature is `RELEASE_TYPE: patch` and opens `"This patch adds ..."`, with a
+   short usage example.
+8. **Tests** — see §4.
+
+For a new _setting_ rather than a generator, steps 1–3 are the same and then:
+add the field to the `Settings` interface and to `defaultSettings()` in
+`src/runner.ts`, map it onto the `hegel_settings_set_*` call where the run's
+settings handle is built, and cover both the default and an override.
+
+## 4. The 100% coverage gate
+
+`just check` enforces 100% lines, branches, functions **and statements**
+(vitest thresholds in `vitest.config.ts` plus `scripts/check-coverage.py` as a
+second pass over `coverage/coverage-summary.json`). Function coverage is the
+one that bites: **an unexercised new binding fails the build.** Tests are part
+of the port, not a follow-up, and a mechanical feature you cannot test is not
+mechanical.
+
+- Integration tests against the real engine are the default. One
+  `tests/<feature>.test.ts` per generator, in the style of `tests/sets.test.ts`:
+  `hegel.test((tc) => { ... }, { testCases: 30 })` with `expect` assertions on
+  the drawn value. Cover every option branch — a `maxSize`-only and a
+  `minSize`-only case, not just both-supplied.
+- `tests/libhegel.test.ts` drives the wrapper directly, including real error
+  paths (bad regex pattern, malformed blob).
+- Branches the real engine cannot be driven into — a NULL return, a specific
+  result code, a null string getter — use the **injected fake `Bindings`**
+  (`fakeBindings({ ... })` in `tests/libhegel.test.ts`, documented in the
+  align skill). Never fake anything the real library can do.
+- A new public export should also be reachable through the namespace re-export
+  checked by `tests/exports.test.ts`.
+- No coverage-ignore comments. Drive the path or inject a fake.
+
+This gate is also the reason not to bind a symbol speculatively: a binding
+with no caller is not a harmless extra, it is a red build.
+
+## 5. Public API discipline
+
+- **Additive only.** Never change or remove existing public API in a port, and
+  do not change what an existing method _does_. If a new engine facility would
+  replace a client-side implementation of the same thing (the engine's
+  `hegel_note` versus `TestCase.note`'s local `console.error`), that is a
+  behavior change, which makes it design-heavy — ledger, not code.
+- **Match the idiom.** Lowercase factory functions returning `Generator<T>`;
+  a single optional options object with optional fields, never positional
+  options; `camelCase` field names mapping to the schema's `snake_case` keys;
+  synchronous draws (the FFI is synchronous — `testAsync` is about the _test
+  body_, not about draws).
+- Keep `src/libhegel.ts`'s header comment's version reference in step with the
+  pin.
+
+## 6. The ledger
+
+`LIBHEGEL-PARITY.md` at the repo root is the porter's memory and the
+workflow's baseline. It lives at the root because `docs/` is gitignored —
+typedoc owns that directory and wipes it.
+
+**Read it before you start.** Its `last_ported` line is the version the
+previous port finished at, and its table already contains the reasoning for
+everything previously skipped; a feature marked _needs design_ stays skipped
+until a human decides otherwise, and you should not re-litigate it.
+
+**Update it before you finish**, in the same PR:
+
+- Move `last_ported` to the new pin. The
+  `.github/workflows/port-libhegel-features.yml` workflow greps this line for
+  its baseline, so keep the format exactly `last_ported: <x.y.z>` on its own
+  line.
+- One row per feature in the delta, with its status and the reason.
+- For anything not ported, the reason must be usable a year later by someone
+  who has not read the changelog.
+
+## 7. When to stop
+
+Stop at the first design decision you cannot make from existing precedent in
+this repo. Do not prototype "something to start the discussion" in public API
+— a draft PR full of guessed surface costs more review than an empty one.
+
+A design-heavy ledger entry states three things:
+
+1. **What the capability is** — in terms of what a user of this library could
+   do with it, not in terms of C symbols.
+2. **Why it needs a human decision** — the specific fork in the road.
+3. **What the options look like** — the two or three shapes you considered,
+   each with what it would cost. This is the part that makes the entry worth
+   writing; without it the next porter starts from zero.
+
+Then move on to the next feature. A port that lands three mechanical features
+and three good write-ups is a success.
+
+## 8. References
+
+- `hegel-c/src/` in hegel-rust **at the release tag** — the implementation, for
+  ownership, error codes, sentinel values, and anything the header comment
+  leaves ambiguous.
+- **hegel-go's `internal/libhegel/` and its public API** — a second, complete
+  binding of the same ABI in another language. Reading how Go exposed a
+  feature is the cheapest sanity check on your reading of the protocol, and on
+  whether a feature is really design-heavy or just unfamiliar.
+- The align skill's koffi section for marshalling; when the marshalling is
+  unclear, prove it with a throwaway script against the real dylib
+  (`node scripts/fetch-libhegel.mjs`) before committing to a binding shape.
+
+## 9. Done
+
+- `just check` passes — prettier, eslint, tsc, typedoc, and vitest at 100%
+  coverage.
+- `RELEASE.md` exists if `src/` changed.
+- `LIBHEGEL-PARITY.md` has `last_ported` at the new pin and a row for every
+  feature in the delta.
+- The PR body lists what was ported and what was skipped, each skip with its
+  reason — the same content as the ledger rows, so a reviewer does not have to
+  open the file to see the verdict.

--- a/.github/workflows/port-libhegel-features.yml
+++ b/.github/workflows/port-libhegel-features.yml
@@ -1,0 +1,173 @@
+name: Port libhegel features
+
+on:
+  # Fires however the pin lands on main — a merged bump PR, a human PR that
+  # carries the bump, or a direct push. Deliberately not keyed to the bump PR
+  # merging: bump PRs are frequently superseded and closed unmerged, and the
+  # pin arrives some other way.
+  push:
+    branches: [main]
+    paths:
+      - "src/libhegel-version.ts"
+  # Manual escape hatch and catch-up: `from` overrides the ledger's baseline.
+  workflow_dispatch:
+    inputs:
+      from:
+        description: "libhegel version to port from (empty = last_ported in LIBHEGEL-PARITY.md)"
+        required: false
+        default: ""
+
+permissions: {}
+
+# One port at a time. Never cancel a run in progress: it may be most of the
+# way through an expensive analysis, and the next run picks up the same
+# baseline from the ledger anyway.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  port:
+    name: port libhegel features
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Generate app token
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
+        id: app-token
+        with:
+          app-id: ${{ vars.HEGEL_RELEASE_APP_ID }}
+          private-key: ${{ secrets.HEGEL_RELEASE_APP_PRIVATE_KEY }}
+          repositories: hegel-typescript
+
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          token: ${{ steps.app-token.outputs.token }} # zizmor: ignore[artipacked]
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: "22"
+
+      - name: Install just
+        run: sudo apt-get update && sudo apt-get install -y just
+
+      - run: npm ci
+
+      # The baseline is the ledger's last_ported, not github.event.before: the
+      # ledger survives force-pushes, stays correct when several bumps land
+      # between runs, and makes catch-up automatic after a failed run.
+      - name: Resolve the version range
+        id: range
+        env:
+          FROM_INPUT: ${{ inputs.from }}
+        run: |
+          set -euo pipefail
+          to=$(sed -n 's/^export const LIBHEGEL_VERSION = "\(.*\)";$/\1/p' src/libhegel-version.ts)
+          if [ -z "$to" ]; then
+            echo "Could not read LIBHEGEL_VERSION from src/libhegel-version.ts." >&2
+            exit 1
+          fi
+
+          from="$FROM_INPUT"
+          if [ -z "$from" ]; then
+            from=$(sed -n 's/^last_ported: \([0-9][0-9A-Za-z.+-]*\)$/\1/p' LIBHEGEL-PARITY.md | head -n1)
+          fi
+          if [ -z "$from" ]; then
+            echo "Could not read 'last_ported: <version>' from LIBHEGEL-PARITY.md." >&2
+            exit 1
+          fi
+
+          echo "from=$from" >> "$GITHUB_OUTPUT"
+          echo "to=$to" >> "$GITHUB_OUTPUT"
+          if [ "$from" = "$to" ]; then
+            echo "Already ported up to libhegel $to; nothing to do."
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Porting libhegel $from -> $to."
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Port the new libhegel features
+        if: steps.range.outputs.changed == 'true'
+        timeout-minutes: 45
+        uses: anthropics/claude-code-action@4d7e1f0cd85743fdc93b1c8040ab54395da024e2 # v1.0.149
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ steps.app-token.outputs.token }}
+          # The pin is usually pushed by hegel-release[bot], so the actor is a
+          # bot. The action blocks bot-initiated runs by default.
+          allowed_bots: hegel-release
+          prompt: |
+            The pinned libhegel version moved from ${{ steps.range.outputs.from }} to
+            ${{ steps.range.outputs.to }} (src/libhegel-version.ts) on this checkout of main.
+
+            Use the port-libhegel-features skill. Work out what capability libhegel gained
+            across that range, port the mechanical features (new generators, settings,
+            result codes, enum values), and write the design-heavy ones up in
+            LIBHEGEL-PARITY.md instead of guessing at an API for them. Update the ledger's
+            last_ported to ${{ steps.range.outputs.to }} and give every feature in the range
+            a row.
+
+            `just check` must pass, including 100% coverage — so tests ship with the port.
+            Add a RELEASE.md if you changed anything under src/ (see the changelog skill).
+            Changes must be additive: never alter or remove existing public API.
+
+            Write a short summary of what you ported and what you skipped, one line per
+            feature with the reason for each skip, to the absolute path
+            /tmp/port-summary.md. It goes in the PR body.
+
+            Do NOT commit or push, and leave no scratch files in the working tree: the next
+            step commits everything it finds.
+          claude_args: >-
+            --allowed-tools "Bash,Edit,Write,Read,Glob,Grep,WebFetch,Skill"
+            --max-turns 150
+
+      # Draft PR off main, never a push to main — so there is no way for this
+      # to re-trigger itself and no retry cap is needed.
+      - name: Push the branch and open/update the draft PR
+        if: steps.range.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          HEGEL_RELEASE_APP_ID: ${{ vars.HEGEL_RELEASE_APP_ID }}
+          VERSION: ${{ steps.range.outputs.to }}
+          FROM_VERSION: ${{ steps.range.outputs.from }}
+        run: |
+          set -euo pipefail
+          git config user.name "hegel-release[bot]"
+          git config user.email "${HEGEL_RELEASE_APP_ID}+hegel-release[bot]@users.noreply.github.com"
+
+          branch="ci/port-hegel-rust-${VERSION}"
+          git checkout -B "$branch"
+          git add -A
+          if git diff --cached --quiet; then
+            echo "No changes to port for libhegel ${VERSION}."
+            exit 0
+          fi
+
+          git commit -m "Port new libhegel ${VERSION} features" \
+            -m "First stab at exposing the capability libhegel gained between ${FROM_VERSION} and ${VERSION}. See LIBHEGEL-PARITY.md for what was skipped and why."
+          git push --force origin "$branch"
+
+          workflow_url="https://github.com/hegeldev/hegel-typescript/blob/main/.github/workflows/port-libhegel-features.yml"
+          title="Port new libhegel ${VERSION} features"
+          {
+            printf '%s\n\n' "A first stab at exposing the capability \`libhegel\` gained between \`${FROM_VERSION}\` and \`${VERSION}\`. Draft: the analysis needs a human read before the code does."
+            printf '%s\n\n' "\`LIBHEGEL-PARITY.md\` records what was ported, what was skipped, and why."
+            printf '%s\n' "<details>"
+            printf '%s\n\n' "<summary>AI-generated summary of this port</summary>"
+            if [ -s "${RUNNER_TEMP}/port-summary.md" ]; then
+              cat "${RUNNER_TEMP}/port-summary.md"
+            else
+              printf '%s\n' "No summary was produced; read the diff and \`LIBHEGEL-PARITY.md\`."
+            fi
+            printf '\n%s\n\n' "</details>"
+            printf '%s\n\n' "---"
+            printf '%s\n' "*Automatically generated by [port-libhegel-features.yml](${workflow_url}).*"
+          } > "${RUNNER_TEMP}/pr-body.md"
+
+          if [ -n "$(gh pr list --head "$branch" --state open --json number --jq '.[].number')" ]; then
+            gh pr edit "$branch" --title "$title" --body-file "${RUNNER_TEMP}/pr-body.md"
+          else
+            gh pr create --draft --title "$title" --body-file "${RUNNER_TEMP}/pr-body.md"
+          fi

--- a/.github/workflows/port-libhegel-features.yml
+++ b/.github/workflows/port-libhegel-features.yml
@@ -115,7 +115,8 @@ jobs:
 
             Write a short summary of what you ported and what you skipped, one line per
             feature with the reason for each skip, to the absolute path
-            /tmp/port-summary.md. It goes in the PR body.
+            ${{ runner.temp }}/port-summary.md. It goes in the PR body, and it is outside
+            the working tree so the commit below does not pick it up.
 
             Do NOT commit or push, and leave no scratch files in the working tree: the next
             step commits everything it finds.
@@ -147,6 +148,27 @@ jobs:
 
           git commit -m "Port new libhegel ${VERSION} features" \
             -m "First stab at exposing the capability libhegel gained between ${FROM_VERSION} and ${VERSION}. See LIBHEGEL-PARITY.md for what was skipped and why."
+
+          # A port PR is opened as a draft precisely so a human finishes it, so
+          # a branch carrying human commits is the expected state, not an edge
+          # case — and re-entry for the same version is easy (a dispatch, or
+          # any pin push while last_ported is behind). Check the *remote*
+          # branch: the checkout is of main and the local branch is fresh.
+          # An author GitHub cannot resolve counts as human; never overwrite
+          # work on an identity we failed to establish.
+          if git ls-remote --exit-code --heads origin "$branch" >/dev/null; then
+            others=$(gh api "repos/${GITHUB_REPOSITORY}/compare/main...${branch}" \
+              --jq '[.commits[] | (if (.author.login // "") != "" then .author.login
+                                   elif (.commit.author.name // "") != "" then .commit.author.name
+                                   else "unknown author" end)] | unique
+                    | map(select(. != "hegel-release" and . != "hegel-release[bot]"))
+                    | join(", ")')
+            if [ -n "$others" ]; then
+              echo "::error::Refusing to force-push ${branch}: it carries commits by ${others}. Land or reset that work, then re-run."
+              exit 1
+            fi
+          fi
+
           git push --force origin "$branch"
 
           workflow_url="https://github.com/hegeldev/hegel-typescript/blob/main/.github/workflows/port-libhegel-features.yml"

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 .claude/skills/*
 !.claude/skills/changelog/
 !.claude/skills/align-libhegel/
+!.claude/skills/port-libhegel-features/
 CLAUDE.local.md
 
 .venv/

--- a/LIBHEGEL-PARITY.md
+++ b/LIBHEGEL-PARITY.md
@@ -1,0 +1,204 @@
+# libhegel parity
+
+What `libhegel` can do, and what `@hegeldev/hegel` exposes of it.
+
+The bump pipeline (`bump-hegel-rust.yml` → the `align-libhegel` skill) is
+API-preserving by design: it keeps the koffi binding compiling and never grows
+the public API. New engine capability therefore has to be picked up
+separately, by `port-libhegel-features.yml` and the
+`port-libhegel-features` skill. This file is that process's memory: a feature
+skipped once and not recorded here is invisible forever.
+
+last_ported: 0.32.5
+
+`last_ported` is the version the last completed port covered. The workflow
+greps this line for its baseline, so keep the format exactly
+`last_ported: <x.y.z>` on a line of its own. It is deliberately behind the pin
+in `src/libhegel-version.ts` while the backlog below is unported.
+
+Status vocabulary:
+
+| Status         | Meaning                                                                     |
+| -------------- | --------------------------------------------------------------------------- |
+| `ported`       | Exposed in the public API.                                                  |
+| `to port`      | Classified mechanical; the shape is settled, the work is not done.          |
+| `needs design` | Requires a public-API decision in TypeScript. Do not guess — see the notes. |
+| `omitted`      | Deliberately not exposed, for the stated reason.                            |
+| `n/a`          | No public surface to expose.                                                |
+
+## 0.32.5 → 0.34.0
+
+Derived by diffing `hegel-c/include/hegel.h` between tags `v0.32.5` and
+`v0.34.0` and reading the `hegel-c/CHANGELOG.md` entries in between. The delta
+is 32 new functions, one new result code, one new run status, two new span
+labels, one changed sentinel value, and three changed signatures. Grouped into
+features:
+
+| Feature                          | libhegel surface                                                                                                                        | Status         |
+| -------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- | -------------- |
+| Recursive generation             | `hegel_new_recursion`, `hegel_recursion_branch` / `_leaf` / `_retry` / `_finish` / `_free`; `HEGEL_E_RETRY`; `HEGEL_LABEL_RECURSIVE`    | `to port`      |
+| Pretty-printer document API      | 21 `hegel_printer_*` entry points, `hegel_test_case_printer`, `hegel_note`                                                              | `needs design` |
+| Stateful testing (round-based)   | `hegel_state_machine_next_group`, `_should_check_invariant`, reworked `hegel_new_state_machine` / `_next_rule` / `_rule_rejected`       | `needs design` |
+| Nondeterministic-run reporting   | `hegel_test_case_is_nondeterministic`, `HEGEL_RUN_STATUS_FAILED_NONDETERMINISTIC`, `HEGEL_LABEL_CONCURRENCY`                            | `omitted`      |
+| Generation and shrinking quality | No ABI surface (0.32.x shrinker work, 0.33.1 integer swarm testing and f32 distribution, 0.33.3/0.33.5 recursion sizing and span guard) | `n/a`          |
+
+### Recursive generation — `to port`
+
+Users can generate recursively defined data (trees, JSON documents) with the
+same distribution every other Hegel frontend gets, instead of hand-rolling a
+depth counter. The engine owns branch probabilities, the depth limit, the leaf
+budget, and a per-value target size; the client drives a protocol and wraps
+each sub-value in a `HEGEL_LABEL_RECURSIVE` span so the shrinker can replace a
+tree with one of its own subtrees.
+
+Classified mechanical because the public shape does not need inventing.
+hegel-rust exposes `gs::recursive(leaf, branch)` (`src/generators/recursive.rs`),
+where the base case is a generator and the recursive step is a function handed
+a subtree generator, with `max_depth` / `max_leaves` options defaulting to 32
+and 100. The TypeScript translation follows the repo's own idiom directly:
+
+```ts
+recursive<T>(
+  leaf: Generator<T>,
+  branch: (subtree: Generator<T>) => Generator<T>,
+  options?: { maxDepth?: number; maxLeaves?: number },
+): Generator<T>;
+```
+
+What the port has to build, beyond the five bindings:
+
+- A `RetryError` for `HEGEL_E_RETRY` (`-10`) alongside `StopTestError` and
+  `AssumeError` in `Libhegel.check`, and the attempt loop that catches it,
+  calls `hegel_recursion_retry`, and restarts from the root. Rust needs
+  `catch_unwind` for this; a thrown error is the natural TypeScript form.
+- `HEGEL_LABEL_RECURSIVE = 35` in `Labels` (`src/testCase.ts`).
+- Recursion methods on the internal `DataSource` interface, since the
+  generator drives the engine directly rather than through the schema IR.
+- Restoring span nesting after an aborted attempt. `TestCase` tracks
+  `spanDepth` privately with no way to unwind it to a mark; hegel-rust has
+  `reset_open_spans_to` for exactly this. This is the one non-obvious piece.
+
+hegel-go binds the protocol in `internal/libhegel/` but exposes nothing and
+never drives the retry loop, so it is not a useful second reading here; use
+hegel-rust's `draw_recursive` / `draw_subtree`.
+
+### Pretty-printer document API — `needs design`
+
+**Capability.** The engine ships an Oppen-style layout engine so a frontend
+can report drawn values through libhegel instead of formatting them itself:
+grouping, breakable and hard breaks, indentation, comments, deferred holes
+filled in later, and speculative regions a rejected draw can retract. Every
+test case owns one document; `hegel_test_case_printer` gets a handle on it and
+`hegel_note` appends note lines. Cloned test-case handles anchor their region
+at the clone point, so concurrent generation renders deterministically.
+
+**Why a human decides.** This library already solves the same problem its own
+way, and adopting the engine's version replaces that rather than adding to it.
+`TestCase.draw` prints `var draw_N = <node:util inspect>` on the final replay
+and `TestCase.note` writes straight to `console.error`. Routing either through
+the document changes where output goes (engine stderr, at the engine's
+timing), what it looks like, and how the two interleave — a behavior change to
+existing public API, which a port is not allowed to make on its own authority.
+Underneath that sit real design forks with no TypeScript precedent to copy:
+hegel-rust built a `PrettyPrintable` trait plus a derive macro plus
+`Generator::print_with` / `print_as_value` / `print_as_debug`, a design that
+leans on traits and macros TypeScript does not have; hegel-go declined the ABI
+entirely and formats values with the standard library's `go/printer`.
+
+**Options.**
+
+1. **Do nothing.** `node:util`'s `inspect` already produces good output for JS
+   values and costs nothing to maintain. The loss is cross-language
+   consistency and any value too large to print flat.
+2. **Adopt `hegel_note` only** — keep `inspect` for drawn values, send
+   `TestCase.note` text to the engine document. Small, but still changes when
+   and where notes appear, and buys little on its own.
+3. **A `PrettyPrintable`-style interface plus opt-in generator hooks** — the
+   closest analogue of hegel-rust, e.g. an optional `prettyPrint(printer)`
+   method recognized on drawn values and a `.printWith()` combinator on
+   `Generator`. The largest surface, and the only option that gets the
+   speculative-region and deferred-hole machinery, which is what makes
+   printing _during_ generation correct under filters and retries.
+
+Option 3 becomes load-bearing if recursive generation lands: the
+Rust implementation wraps each recursion attempt in a speculative print region
+so discarded attempts do not leak into the report. Without a printer there is
+nothing to leak, so the two are independent for now — but they stop being
+independent once printing exists.
+
+### Stateful testing (round-based) — `needs design`
+
+**Capability.** Model-based testing: the user declares rules and invariants,
+the engine schedules them, shrinks the failing sequence, and — since 0.33.0 —
+can run rules concurrently across worker threads, with rules assigned to
+concurrency groups so that only one group runs per round.
+
+**Why a human decides.** This library has no stateful testing at all, so this
+is not a delta to catch up on but a feature to design. There is no `Pool`, no
+state machine, no rule concept anywhere in `src/`, and the 0.33.0/0.34.0
+changes (the round protocol, `worker_index`, `HEGEL_STATE_MACHINE_DONE` moving
+from `-1` to `INT64_MIN`) only matter once there is a caller to change. The
+two existing frontends made opposite host-language choices — hegel-rust uses a
+`StateMachine` trait with `#[hegel::state_machine]` attribute macros,
+hegel-go discovers rules by reflecting over `Rule…` / `Invariant…` method-name
+prefixes — and neither translates to TypeScript, which has no macros and no
+useful runtime reflection over method intent.
+
+**Options** (the sequential API first; concurrency is a second decision).
+
+1. **A class with decorated or prefixed methods.** Familiar from
+   Hypothesis's `RuleBasedStateMachine`, but TypeScript decorators are still
+   awkward to ship (`experimentalDecorators`, emit-target coupling), and
+   name-prefix reflection is fragile in a language with minification.
+2. **A declarative object of rules**, e.g.
+   `stateful({ initial, rules: { push: { group, run(state, tc) {…} } }, invariants: {…} })`.
+   No decorators, no reflection, straightforward to type; less familiar to
+   users coming from Hypothesis.
+
+Concurrency is a separate and larger question: `max_concurrency > 1` means
+real worker threads, which for this library means `node:worker_threads`,
+structured-clone boundaries on user state, and driving cloned test-case
+handles across threads through koffi. **Sequential-only is a legitimate first
+milestone** — it is the degenerate case of the same protocol (all-zero rule
+groups, concurrency bounds `1, 1`, no workers, `hegel_state_machine_next_group`
+between rules) and it needs no threading story. Decide sequential first.
+
+`hegel_state_machine_should_check_invariant` (new in 0.34.0) is part of
+whatever lands: it is the engine's per-invariant sampling decision at each
+round boundary, with the guaranteed initial and final checks run
+unconditionally. hegel-go, pinned to 0.33.2, does not bind it and runs every
+invariant every round.
+
+### Nondeterministic-run reporting — `omitted`
+
+`hegel_test_case_is_nondeterministic`, `HEGEL_RUN_STATUS_FAILED_NONDETERMINISTIC`
+(`3`) and `HEGEL_LABEL_CONCURRENCY` (`34`) exist to support concurrent
+stateful runs, which cannot be replayed: the frontend captures the trace at
+discovery, and skips the final replay and the reproducer. Only a state machine
+created with `max_concurrency > 1` declares a run nondeterministic, so nothing
+this library can construct reaches any of it.
+
+Omitted rather than ported because the constants alone buy nothing and the
+handling they imply is unreachable code under the 100% coverage gate. One
+hazard to remember when stateful testing does land: `src/runner.ts` treats any
+run status that is neither `PASSED` nor `ERROR` as `FAILED` and replays each
+counterexample's blob, which is exactly what a nondeterministic failure must
+not do.
+
+### Generation and shrinking quality — `n/a`
+
+Engine-internal improvements with no ABI surface, which arrive with the pin:
+cheaper shrinking and better branch escape (0.32.4), a fresh stall budget per
+scheduling round (0.32.5), swarm-testing-based boundary-value injection for
+wide integer ranges and fixed unbounded `f32` distribution (0.33.1), and two
+recursion sizing fixes (0.33.3, 0.33.5). Listed so a later reader can see they
+were considered.
+
+## Known gaps outside this range
+
+This table covers only `0.32.5 → 0.34.0`. Capability that predates `0.32.5`
+and is still unexposed has never been inventoried. The clearest example:
+`Labels` in `src/testCase.ts` mirrors `HEGEL_LABEL_*` values 1–15 exactly, but
+upstream defines up to 35 — the per-primitive labels (`HEGEL_LABEL_INTEGER`,
+`_FLOAT`, `_STRING`, `_REGEX`, …, 16–33) are unused here. Auditing that
+backlog is its own job, not part of a version-range port.


### PR DESCRIPTION
Automation that attempts a first stab at porting new libhegel capability when the pin moves, plus the analysis of the capability we are currently missing. No feature is ported here.

<details>
<summary>AI-generated description of this PR</summary>

## The gap

The bump pipeline — `bump-hegel-rust.yml` → the `align-libhegel` skill → CI — is API-preserving on purpose. The align skill's instruction is to bind only what the front end already uses and not to change the public API, so a release that adds engine *capability* passes through it untouched: the binding still compiles, and users see nothing new. Nothing in the pipeline is wrong; it is just not the job.

Measured on the current pin. Between `v0.32.5` (what we pin) and `v0.34.0` (latest), libhegel gained 32 functions, a result code, a run status, two span labels, one changed sentinel value and three changed signatures. We expose none of it.

## Three deliverables

**`.claude/skills/port-libhegel-features/SKILL.md`** — the complement to `align-libhegel`. How to diff `hegel-c/include/hegel.h` between two release tags and read the `hegel-c/CHANGELOG.md` entries in between; how to classify each feature as mechanical, design-heavy, or not applicable; what porting a generator actually costs in this repo (traced end to end from `arrays`/`sets`: koffi prototype, `Bindings` field, `Libhegel` method, schema IR case in `generate.ts`, the public generator and its `index.ts` export, typedoc-visible docs, `RELEASE.md`, tests); the 100% coverage gate, which makes an unexercised binding a red build rather than harmless dead code; and when to stop. Cross-referenced from `align-libhegel` in both directions.

**`.github/workflows/port-libhegel-features.yml`** — triggers on a push to `main` touching `src/libhegel-version.ts`, plus `workflow_dispatch` with an optional `from`. Reads the baseline from the ledger, runs the skill under `claude-code-action`, and opens a **draft** PR on `ci/port-hegel-rust-<version>`. Auth, token scoping, action SHAs and the bot git identity are copied from `bump-hegel-rust.yml`; no new credential wiring.

The force-push is guarded. A port PR is a draft *specifically so a human finishes it*, so a branch carrying human commits is the expected state rather than an edge case — and re-entry for the same version is cheap (a dispatch, or any pin push while `last_ported` is behind). Before pushing, the step resolves the authors of the **remote** branch's commits and fails loudly, naming them, rather than overwriting. The author resolution is lifted from `bump-hegel-rust.yml`'s supersede step, including its treatment of an unresolvable identity as human.

**`LIBHEGEL-PARITY.md`** — the ledger. A machine-readable `last_ported` line the workflow greps, and a table of libhegel capability against this library's status with the reasoning for every skip. Set to `0.32.5`, so the first live run picks up exactly the backlog below.

## The three design calls, and why

**Draft PR off main from a separate workflow, after the pin lands.** Porting is speculative work that needs a human read; the bump is routine and should merge on its own schedule. Folding the port into the bump PR would hold the pin hostage to a design conversation.

**Trigger on the pin file, not on the bump PR merging.** Bump PRs frequently do not merge as bump PRs — hegel-cpp landed 0.34.0 inside a human PR and closed bump PR #112 unmerged. A push trigger fires however the pin arrives.

**Baseline from the ledger, not `github.event.before`.** It survives force-pushes, stays correct when several bumps land between runs, and makes catch-up automatic after a failed run. It is also the only place a *skipped* feature is remembered.

**Port the mechanical, skip-with-analysis the design-heavy.** A bad guess at a public API is worse than no public API: it ships surface the library then has to keep or break, and it forecloses the design the owner would have chosen.

## The verdict for 0.32.5 → 0.34.0

Derived by following the skill's own procedure against the two tags — the proof that the procedure works, and the first thing worth reading.

| Feature | Status |
|---|---|
| Recursive generation (`hegel_new_recursion` + 5, `HEGEL_E_RETRY`, `HEGEL_LABEL_RECURSIVE`) | **to port** — mechanical |
| Pretty-printer document API (21 `hegel_printer_*`, `hegel_test_case_printer`, `hegel_note`) | **needs design** |
| Stateful testing, round-based (`_next_group`, `_should_check_invariant`, reworked `hegel_new_state_machine`/`_next_rule`/`_rule_rejected`) | **needs design** |
| Nondeterministic-run reporting (`hegel_test_case_is_nondeterministic`, `HEGEL_RUN_STATUS_FAILED_NONDETERMINISTIC`, `HEGEL_LABEL_CONCURRENCY`) | **omitted** — unreachable without stateful |
| Generation and shrinking quality (0.32.4–0.33.5) | **n/a** — no ABI surface |

Recursive generation is classified mechanical because the shape does not need inventing: hegel-rust ships `gs::recursive(leaf, branch)` with `max_depth`/`max_leaves` defaulting to 32 and 100, which translates straight into this repo's options-object idiom. The ledger names the four non-obvious pieces, of which one is real — restoring span nesting after an aborted attempt, which `TestCase` has no way to do today.

The printer and stateful entries are design-heavy for the same underlying reason: hegel-rust and hegel-go made *opposite* host-language choices for both (traits plus derive macros versus reflection over method-name prefixes; adopt the ABI versus decline it and use `go/printer`), and neither translates to TypeScript. The printer additionally cannot be adopted without changing what `TestCase.note` and `TestCase.draw` already do, which a port is not allowed to decide on its own. Each entry states the capability, the specific fork in the road, and two or three concrete options with their costs.

## Verification

- `just check` passes: prettier, eslint, `tsc --noEmit`, typedoc, and vitest at 100% statements/branches/functions/lines.
- `uvx zizmor==1.23.1 --format plain .github/` — no findings. The single `# zizmor: ignore[artipacked]` is on the app-token checkout and is copied verbatim from `bump-hegel-rust.yml`; no new suppressions.
- Workflow YAML parses; all four embedded `run:` blocks pass `bash -n`. Both version-extraction `sed`s were dry-run against the real `src/libhegel-version.ts` and `LIBHEGEL-PARITY.md`, and the force-push guard's `gh api` + `jq` was dry-run against this branch (correctly resolves a human author) and against a nonexistent branch.
- The agent's summary and the shell that embeds it both use `runner.temp` — `${{ runner.temp }}` interpolated into the prompt, `${RUNNER_TEMP}` in the `run:` block. It is outside the working tree, so `git add -A` cannot sweep it into the commit.
- `git status` confirms the new skill is tracked — `.gitignore` whitelists `.claude/skills/*` entries individually, so the new directory needed an explicit `!` line.

The ledger lives at the repo root rather than `docs/`, because `docs/` is gitignored typedoc output and `typedoc` wipes the directory on every `just check-docs`.

## Live testing

The workflow cannot be exercised before merge: `push`-to-`main` triggers only run from the default branch. After merge, `workflow_dispatch` is the end-to-end test — but note that with the pin *still* at `0.32.5`, dispatching with `from: 0.32.5` resolves to an empty range and correctly exits 0 as a no-op. To exercise it against the current pin, dispatch with an older `from` (e.g. `0.31.0`). The natural full-scale test is the 0.34.0 bump landing, which produces exactly the `0.32.5 → 0.34.0` backlog analysed above.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
